### PR TITLE
Localhost installation testing 3

### DIFF
--- a/.env
+++ b/.env
@@ -1,24 +1,34 @@
-# Do not assign false to these variables. Rather leave them empty e.g NOT YII_ENV=false. You can assign a string to these variables e.g. PASSWORD=mypasswrd
-# Used in: config\common\params with yii sentry e.g YII_ENV=prod
-YII_ENV=
+# The session related environment variables $_ENV listed here are used in the autoload.php function
+# which loads them into non-session related $_SERVER variables. Consistent boolean values entered here are 
+# ensured in the autoload.php function's filter_var function.
+# see: https://www.php.net/manual/en/function.filter-var.php#121263
+# see: Testing of boolean values: At command line e.g. C:\wamp64\www\invoice>php php-space-filter-var-test.php
 
-# This setting should remain on empty(production) i.e YII_DEBUG= except during development i.e YII_DEBUG=true and empty for testing i.e. YII_DEBUG= 
+# Used in: config\common\params with yii sentry e.g YII_ENV=prod
+# String Value: e.g prod or dev
+YII_ENV=dev
+
 # Used, inter alia, in: src\viewInjection\LayoutViewInjection with $debugMode
-# Any string value e.g YII_DEBUG=afadfaf will be equated to true. i.e not empty
+# Boolean Values that are acceptable and will be passed to the filter_var in autoload.php function which ensures a boolean is output are namely: 
+# ...that equate to true:    'true', true, TRUE, 'TRUE', "TRUE", '1', "1", 1
+# ...that equate to false:   'false', false, FALSE, 'FALSE', "FALSE", '0', "0", 0, {nothing i.e no value}, "lots of meaningless data"
+# ...any number of spaces can be put after the equal sign and before the boolean equivalent value
+# ...Note: The final value can be observed under the application's debug mode menu ... FAQ'S ... Php Details ? Variables for testing purposes
+# ...Note: Any values not in the above lists e.g. asdfasdf will be equated to false
 YII_DEBUG=true
 
-# This setting should remain empty i.e BUILD_DATABASE= except during setup i.e. BUILD_DATABASE=true, and BUILD_DATABASE=true to entities
-# Used in: config\common\params
-BUILD_DATABASE=
+# Used in: config\common\params to install the tables for the database on initial setup
+# Used in: src\ViewInjection\LayoutViewInjection to inform if setting is still true which will impact performance
+# Boolean Value
+BUILD_DATABASE=false
 
-# Used in: config\common\params
+# Used in: config\common\params. Insert a string here without quotes
 SENTRY_DSN=
 
-# This setting should remain blank
 #Used in config\common\bootstrap and config\web\di\application
 BASE_URL=
 
-# Used in: config\common\params. Insert a string here withouth quotes.
+# Used in: config\common\params.  a string here withouth quotes.
 SYMFONY_MAILER_USERNAME=
 
 # Used in: config\common\params. Insert a string here without quotes.

--- a/autoload.php
+++ b/autoload.php
@@ -2,6 +2,30 @@
 
 declare(strict_types=1);
 
+/**
+ * autoload.php has been Psalm level 1 tested according to setting in psalm.xml at root.
+ * i.e on the command line run e.g c:\wamp64\wwww\invoice>php ./vendor/bin/psalm autoload.php
+ * 
+ * Result:
+ * 
+ * Target PHP version: 8.3 (inferred from composer.json) Enabled extensions: dom (unsupported extensions: fileinfo, pdo_sqlite).
+ * Scanning files...
+ * Analyzing files...
+ *
+ * ░
+ * ------------------------------
+ *
+ *       No errors found!
+ *
+ * ------------------------------
+ *
+ * Checks took 23.69 seconds and used 160.243MB of memory
+ * Psalm was able to infer types for 100% of the codebase
+ * 
+ * In addition, session related $_ENV variables are saved to server related $_SERVER variables and
+ * can be viewed under the application's debug mode menu's FAQ's Php Details? Variables
+ */
+
 use Dotenv\Dotenv;
 
 require_once __DIR__ . '/vendor/autoload.php';
@@ -12,5 +36,20 @@ $dotenv->load();
 $_ENV['YII_ENV'] = strlen(($_ENV['YII_ENV'])) == 0 ? null : $_ENV['YII_ENV'];
 $_SERVER['YII_ENV'] = $_ENV['YII_ENV'];
 
-$_ENV['YII_DEBUG'] = strlen(($_ENV['YII_DEBUG'])) == 0 ? false : true;
+$_ENV['YII_DEBUG'] = (strlen(($_ENV['YII_DEBUG'])) == 0 
+        ? false 
+        : filter_var($_ENV['YII_DEBUG'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
 $_SERVER['YII_DEBUG'] = $_ENV['YII_DEBUG'];
+
+
+$_ENV['BUILD_DATABASE'] = strlen(($_ENV['BUILD_DATABASE'])) == 0 
+        ? false  
+        : filter_var($_ENV['BUILD_DATABASE'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+$_SERVER['BUILD_DATABASE'] = $_ENV['BUILD_DATABASE'];
+
+/**
+ * Building the database takes longer than usual and the .env $_ENV['BUILD_DATABASE'] should be set to false afterwards
+ * https://stackoverflow.com/questions/3829403/how-to-increase-the-execution-timeout-in-php
+ */
+$buildDatabase = $_SERVER['BUILD_DATABASE'];
+$buildDatabase ? ini_set('max_execution_time', 360) : '';

--- a/composer.lock
+++ b/composer.lock
@@ -1365,16 +1365,16 @@
         },
         {
             "name": "cycle/schema-builder",
-            "version": "v2.10.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cycle/schema-builder.git",
-                "reference": "32cff8ffd51d6b9b1de572dabeb28fd5b87a4fc2"
+                "reference": "5345eb43c4e2d558ec8f16e4643da98e01734fe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cycle/schema-builder/zipball/32cff8ffd51d6b9b1de572dabeb28fd5b87a4fc2",
-                "reference": "32cff8ffd51d6b9b1de572dabeb28fd5b87a4fc2",
+                "url": "https://api.github.com/repos/cycle/schema-builder/zipball/5345eb43c4e2d558ec8f16e4643da98e01734fe2",
+                "reference": "5345eb43c4e2d558ec8f16e4643da98e01734fe2",
                 "shasum": ""
             },
             "require": {
@@ -1407,9 +1407,9 @@
             "description": "Cycle ORM Schema Builder",
             "support": {
                 "issues": "https://github.com/cycle/schema-builder/issues",
-                "source": "https://github.com/cycle/schema-builder/tree/v2.10.0"
+                "source": "https://github.com/cycle/schema-builder/tree/v2.11.0"
             },
-            "time": "2024-10-22T21:24:36+00:00"
+            "time": "2024-11-08T11:56:27+00:00"
         },
         {
             "name": "cycle/schema-migrations-generator",
@@ -12774,12 +12774,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/db.git",
-                "reference": "42181e13bf2e538ab655a91d7815d171af25b744"
+                "reference": "e29b097a29fa3e6ead3f473d7a11c94cb5c239f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/db/zipball/42181e13bf2e538ab655a91d7815d171af25b744",
-                "reference": "42181e13bf2e538ab655a91d7815d171af25b744",
+                "url": "https://api.github.com/repos/yiisoft/db/zipball/e29b097a29fa3e6ead3f473d7a11c94cb5c239f7",
+                "reference": "e29b097a29fa3e6ead3f473d7a11c94cb5c239f7",
                 "shasum": ""
             },
             "require": {
@@ -12853,7 +12853,7 @@
                     "type": "opencollective"
                 }
             ],
-            "time": "2024-10-18T19:19:16+00:00"
+            "time": "2024-11-08T01:44:05+00:00"
         },
         {
             "name": "yiisoft/db-mysql",
@@ -12861,12 +12861,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/db-mysql.git",
-                "reference": "ccb8b73b66f0c0687e8cc9a7085e1b94c3b82120"
+                "reference": "b8ffabc50d724a308820aea4b25e7aa1eb7e63b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/db-mysql/zipball/ccb8b73b66f0c0687e8cc9a7085e1b94c3b82120",
-                "reference": "ccb8b73b66f0c0687e8cc9a7085e1b94c3b82120",
+                "url": "https://api.github.com/repos/yiisoft/db-mysql/zipball/b8ffabc50d724a308820aea4b25e7aa1eb7e63b4",
+                "reference": "b8ffabc50d724a308820aea4b25e7aa1eb7e63b4",
                 "shasum": ""
             },
             "require": {
@@ -12929,7 +12929,7 @@
                     "type": "opencollective"
                 }
             ],
-            "time": "2024-10-18T07:49:35+00:00"
+            "time": "2024-11-08T02:29:56+00:00"
         },
         {
             "name": "yiisoft/definitions",
@@ -16079,12 +16079,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii-bootstrap5.git",
-                "reference": "1b159fe8f0e8a429bde5c3501cd164c2c643bf7d"
+                "reference": "8b574de190e057b75d115ccaffe6b8f59e8d550c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii-bootstrap5/zipball/1b159fe8f0e8a429bde5c3501cd164c2c643bf7d",
-                "reference": "1b159fe8f0e8a429bde5c3501cd164c2c643bf7d",
+                "url": "https://api.github.com/repos/yiisoft/yii-bootstrap5/zipball/8b574de190e057b75d115ccaffe6b8f59e8d550c",
+                "reference": "8b574de190e057b75d115ccaffe6b8f59e8d550c",
                 "shasum": ""
             },
             "require": {
@@ -16148,7 +16148,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-11-06T08:55:49+00:00"
+            "time": "2024-11-08T11:06:26+00:00"
         },
         {
             "name": "yiisoft/yii-console",

--- a/config/common/params.php
+++ b/config/common/params.php
@@ -293,8 +293,7 @@ return [
          * 3. Once the changes have been reflected and you have checked them via e.g. phpMyAdmin revert back to the original settings
          * Mode: PhpFileSchemaProvider::MODE_WRITE_ONLY : PhpFileSchemaProvider::MODE_READ_AND_WRITE \ 
          */
-        'mode' => PhpFileSchemaProvider::MODE_READ_AND_WRITE,
-        //'mode' => PhpFileSchemaProvider::MODE_WRITE_ONLY,  
+        'mode' => $_ENV['BUILD_DATABASE'] ? PhpFileSchemaProvider::MODE_WRITE_ONLY : PhpFileSchemaProvider::MODE_READ_AND_WRITE,
         'file' => 'runtime/schema.php'
       ],
       FromConveyorSchemaProvider::class => [

--- a/php-space-filter-var-test.php
+++ b/php-space-filter-var-test.php
@@ -1,0 +1,11 @@
+<?php
+    /**
+     * @see https://www.php.net/manual/en/function.filter-var.php divinity76 at gmail dot com 
+     * Testing various values that may be input as an environment variable in a .env file using 'filter_var'
+     * To test run on the command line e.g. C:\wamp64\www\invoice>php php-space-filter-var-test.php
+     */
+    $vals = ['true', 'True', 'TRUE', 'false', 'False', 'FALSE', "false", "FALSE", true, false, 0, 1];
+    foreach($vals as $val){
+        echo var_export($val,true).': ';   var_dump(filter_var($val,FILTER_VALIDATE_BOOLEAN,FILTER_NULL_ON_FAILURE));
+    }
+?>

--- a/public/index.php
+++ b/public/index.php
@@ -36,8 +36,8 @@ require_once dirname(__DIR__) . '/autoload.php';
 // Run HTTP application runner
 $runner = new HttpApplicationRunner(
     rootPath: dirname(__DIR__),
-    debug: $_ENV['YII_DEBUG'],
-    checkEvents: $_ENV['YII_DEBUG'],
+    debug: !empty($_ENV['YII_DEBUG']) ? $_ENV['YII_DEBUG'] : false,
+    checkEvents: !empty($_ENV['YII_DEBUG']) ? $_ENV['YII_DEBUG'] : false,
     environment: $_ENV['YII_ENV']
 );
 $runner->run();

--- a/requirements.php
+++ b/requirements.php
@@ -9,6 +9,13 @@ $requirementsChecker = new RequirementsChecker();
 // Add here the conditions that must be verified
 $config = [
     [
+        'name' => 'Maximum Execution Time of 360 is required.',
+        'mandatory' => true,
+        'condition' => $requirementsChecker->checkMaxExecutionTime('360'),
+        'by' => '<a href="https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time">php.ini setting</a>',
+        'memo' => 'A php.ini max_execution_time minimum of 360 is required for installation. The autoloader will attempt to reset the maximum execution time if currently set to less than 360.',
+    ],
+    [
         'name' => 'PHP version',
         'mandatory' => true,
         'condition' => version_compare(PHP_VERSION, '8.3.0', '>='),

--- a/resources/messages/en/app.php
+++ b/resources/messages/en/app.php
@@ -989,7 +989,7 @@ return [
     'invoice.email.default' => 'Default',
     'invoice.email.default.none.set' => 'No default has been set',
     'invoice.email.from.dropdown' => 'From Email Dropdown Email Addresses to be included in MailerQuote Form and MailerInv Form',
-    'invoice.email.exception' => 'Emailing Exception: ',
+    'invoice.email.exception' => 'Emailing Exception.',
     'invoice.email.include' => 'Include',
     'invoice.email.log' => 'Invoices Emailed Log',
     'invoice.email.logs' => 'Invoices Emailed Logs',

--- a/resources/views/invoice/info/invoice.php
+++ b/resources/views/invoice/info/invoice.php
@@ -47,6 +47,12 @@
 <p>Introducing India's PayTm payment gateway's QR code method of payment and comparing this with Stripe's method.</p>
 <p>A General Sales Tax (GST) Tax System will have to be implemented first for this purpose.</p>
 <p>Testing Credit Notes against Invoices with refunds (if payment made) linked to each of the payment gateways.</p>
+<p><b>9th November 2024</b></p>
+<p>1. Retest the .env and autoload files with Psalm Level 1 and filter_var function. Changes made.<p>
+<p>2. public/index.php and yii console file at the root tested. Changes made.<p>
+<p>3. The build database boolean value appears under performance on the application's menu now and warns if it has not been set back to false after setup.<p> 
+<p>4. Include a php-space-filter-var-test.php function for testing .env values at the command line using the filter_var function.</p>
+<p>5. If signup fails due to no internet connection, token 'disabled' with: 'already_used_token' and a time value. The admin has to make the signed up userinv status active. </p>
 <p><b>7th November 2024</b></p>
 <p>1. Remove the email field from userinv entity/table although the relation getUser is used to retrieve the email field in the user table.</p>
 <p>2. The User entity email field is shown 'disabled' in the userinv forms.</p>

--- a/resources/views/layout/invoice.php
+++ b/resources/views/layout/invoice.php
@@ -53,6 +53,7 @@ use Yiisoft\Yii\Bootstrap5\Offcanvas;
  * @var Yiisoft\Translator\TranslatorInterface $translator
  * @var Yiisoft\View\WebView $this
  * @var bool $isGuest
+ * @var bool $buildDatabase
  * @var bool $debugMode
  * @var string $csrf
  * @var string $companyLogoHeight 
@@ -476,12 +477,15 @@ $this->beginPage();
                       ['label' => $translator->translate('invoice.platform.xdebug') . ' ' . $xdebug, 'options' => ['class' => 'nav fs-4', 'data-bs-toggle' => 'tooltip', 'title' => 'Via Wampserver Menu: Icon..Php 8.1.8-->Php extensions-->xdebug 3.1.5(click)-->Allow php command prompt to restart automatically-->(click)Restart All Services-->No typing in or editing of a php.ini file!!']],
                       ['label' => '...config/common/params.php SyncTable currently not commented out and PhpFileSchemaProvider::MODE_READ_AND_WRITE...fast....MODE_WRITE_ONLY...slower'],
                       ['label' => 'php.ini: opcache.memory_consumption (pref 128) = '. (ini_get('opcache.memory_consumption')), 'options' => ['data-bs-toggle' => 'tooltip', 'title' => 'e.g. change manually in C:\wamp64\bin\php\php8.1.13\phpForApache.ini and restart all services.']],
+                      ['label' => 'php.ini: opcache.memory_consumption (pref 128) = '. (ini_get('opcache.memory_consumption')), 'options' => ['data-bs-toggle' => 'tooltip', 'title' => 'e.g. change manually in C:\wamp64\bin\php\php8.1.13\phpForApache.ini and restart all services.']],
                       ['label' => 'php.ini: oopcache.interned_strings_buffer (pref 8) = '. (ini_get('opcache.interned_strings_buffer'))],
                       ['label' => 'php.ini: opcache.max_accelerated_files (pref 4000) = '. (ini_get('opcache.max_accelerated_files'))],
                       ['label' => 'php.ini: opcache.revalidate_freq (pref 60) = '. (ini_get('opcache.revalidate_freq'))],
                       ['label' => 'php.ini: opcache.enable (pref 1) = ' . (ini_get('opcache.enable'))],
                       ['label' => 'php.ini: opcache.enable_cli (pref 1) = ' .(ini_get('opcache.enable_cli'))],
-                      ['label' => 'php.ini: opcache.jit (pref see nothing) = '. (ini_get('opcache.jit'))],  
+                      ['label' => 'php.ini: opcache.jit (pref see nothing) = '. (ini_get('opcache.jit'))],
+                      ['label' => 'php.ini: max_execution_time (pref 360) = '. (ini_get('max_execution_time'))],
+                      ['label' => '.env: BUILD_DATABASE= (pref see nothing) = '. ($buildDatabase ? 'You have built the database using BUILD_DATABASE=true, now assign the environment varirable to nothing i.e. BUILD_DATABASE=' : '✅')],  
                       ['label' => 'config.params: yiisoft/yii-debug: enabled , disable for improved performance'],
                       ['label' => 'config.params: yiisoft/yii-debug-api: enabled, disable for improved performance'],
                     ],

--- a/src/Auth/Controller/AuthController.php
+++ b/src/Auth/Controller/AuthController.php
@@ -66,6 +66,7 @@ final class AuthController
                      *      and the userinv account's status field is made active i.e. 1
                      */
                     if ($status || $userId == 1) {
+                        $userId == 1 ? $this->disableEmailVerificationToken($tR, '1') : '';
                         if ($identity instanceof CookieLoginIdentityInterface && $loginForm->getPropertyValue('rememberMe')) {
                             return $cookieLogin->addCookie($identity, $this->redirectToInvoiceIndex());
                         }
@@ -76,14 +77,7 @@ final class AuthController
                          * the admin will have to make the user active via Settings Invoice User Account AND assign the user an added client
                          * Also the token that was originally assigned on signup, must now be 'disabled' because the admin is responsible for making the user active
                          */
-                        $token = $tR->findTokenByIdentityIdAndType($userId, self::EMAIL_VERIFICATION_TOKEN);
-                        if (null !== $token) {
-                            /**
-                             * @see https://github.com/search?q=repo%3Ayiisoft%2Fyii2-app-advanced%20already_&type=code
-                             */
-                            $token->setToken('already_used_token_'.time());
-                            $tR->save($token);
-                        }
+                        $this->disableEmailVerificationToken($tR, $userId);
                         return $this->redirectToAdminMustMakeActive();
                     }
                 }
@@ -93,6 +87,23 @@ final class AuthController
         }
 
         return $this->viewRenderer->render('login', ['formModel' => $loginForm]);
+    }
+    
+    public function disableEmailVerificationToken(
+        TokenRepository $tR,    
+        ?string $userId = null
+    ) : void 
+    {
+        if (null !== $userId) {    
+            $token = $tR->findTokenByIdentityIdAndType($userId, self::EMAIL_VERIFICATION_TOKEN);
+            if (null !== $token) {
+                /**
+                 * @see https://github.com/search?q=repo%3Ayiisoft%2Fyii2-app-advanced%20already_&type=code
+                 */
+                $token->setToken('already_used_token_'.time());
+                $tR->save($token);
+            }
+        }    
     }
 
     public function logout(): ResponseInterface

--- a/src/ViewInjection/LayoutViewInjection.php
+++ b/src/ViewInjection/LayoutViewInjection.php
@@ -104,10 +104,11 @@ final class LayoutViewInjection implements LayoutParametersInjectionInterface
         $stopSigningUp = $this->settingRepository->getSetting('stop_signing_up') == '1' ? true : false;
         $stopLoggingIn = $this->settingRepository->getSetting('stop_logging_in') == '1' ? true : false;
         /**
-         * @see .env.php $_ENV['YII_DEBUG'] located in the root (first) folder
+         * @see .env.php $_ENV['YII_DEBUG'] and $_ENV['BUILD_DATABASE'] located in the root (first) folder
          * @see {root} autoload.php
          */
-        $debugMode = $_SERVER['YII_DEBUG'] == '1' ? true : false;
+        $debugMode = $_ENV['YII_DEBUG'] == '1' ? true : false;
+        $buildDatabase = $_ENV['BUILD_DATABASE'] == '1' ? true : false;
         // Record the debugMode in a setting so that 'debug_mode' can be used in e.g. salesorder\guest.php`
         $this->settingRepository->debugMode($debugMode);
         $user = $identity instanceof Identity ? $identity->getUser() : null;
@@ -131,6 +132,7 @@ final class LayoutViewInjection implements LayoutParametersInjectionInterface
         return [
             'title' => 'Home',
             'logoPath' => $logoPath,
+            'buildDatabase' => $buildDatabase,
             'debugMode' => $debugMode,
             'stopSigningUp' => $stopSigningUp,
             'stopLoggingIn' => $stopLoggingIn,

--- a/yii
+++ b/yii
@@ -10,8 +10,8 @@ require_once __DIR__ . '/autoload.php';
 // Run console application runner
 $runner = new ConsoleApplicationRunner(
     rootPath: __DIR__,
-    debug: $_ENV['YII_DEBUG'],
-    checkEvents: $_ENV['YII_DEBUG'],
+    debug: !empty($_ENV['YII_DEBUG']) ? $_ENV['YII_DEBUG'] : false,
+    checkEvents: !empty($_ENV['YII_DEBUG']) ? $_ENV['YII_DEBUG'] : false,
     environment: $_ENV['YII_ENV']
 );
 $runner->run();


### PR DESCRIPTION
9th November 2024
1. Retest the .env and autoload files with Psalm Level 1 and filter_var function.
2. public/index.php and yii console file at the root tested.
3. The build database boolean value appears under performance on the application's menu now and warns if it has not been set back to false after setup.
4. Include a php-space-filter-var-test.php function for testing .env values at the command line using the filter_var function.
5. If signup fails due to no internet connection, token 'disabled' with: 'already_used_token' and a time value. The admin has to make the signed up userinv status active.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
