### PR TITLE
Potential fix for code scanning alert no. 154: Unsafe jQuery plugin

### DIFF
--- a/src/Invoice/Asset/jquery-ui-1.14.0/jquery-ui.js
+++ b/src/Invoice/Asset/jquery-ui-1.14.0/jquery-ui.js
@@ -1098,7 +1098,7 @@ $.extend( Datepicker.prototype, {
 
 	/* Action for selecting a new month/year. */
 	_selectMonthYear: function( id, select, period ) {
-		var target = $( id ),
+		var target = $.find( id ),
 			inst = this._getInst( target[ 0 ] );
 
 		inst[ "selected" + ( period === "M" ? "Month" : "Year" ) ] =
@@ -1112,7 +1112,7 @@ $.extend( Datepicker.prototype, {
 	/* Action for selecting a day. */
 	_selectDay: function( id, month, year, td ) {
 		var inst,
-			target = $( id );
+			target = $.find( id );
 
 		if ( $( td ).hasClass( this._unselectableClass ) || this._isDisabledDatepicker( target[ 0 ] ) ) {
 			return;
@@ -1128,14 +1128,14 @@ $.extend( Datepicker.prototype, {
 
 	/* Erase the input field and hide the date picker. */
 	_clearDate: function( id ) {
-		var target = $( id );
+		var target = $.find( id );
 		this._selectDate( target, "" );
 	},
 
 	/* Update the input field with the selected date. */
 	_selectDate: function( id, dateStr ) {
 		var onSelect,
-			target = $( id ),
+			target = $.find( id ),
 			inst = this._getInst( target[ 0 ] );
 
 		dateStr = ( dateStr != null ? dateStr : this._formatDate( inst ) );


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/invoice/security/code-scanning/154](https://github.com/rossaddison/invoice/security/code-scanning/154)

To fix the problem, we need to ensure that the `id` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the `id` to the jQuery selector. The `jQuery.find` method interprets the input strictly as a CSS selector, which mitigates the risk of XSS.

We will replace instances where `id` is directly used in jQuery selectors with `jQuery.find(id)` to ensure safe interpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
