### PR TITLE
Potential fix for code scanning alert no. 148: Unsafe HTML constructed from library input

### DIFF
--- a/src/Invoice/Asset/jquery-ui-1.14.0/external/jquery/jquery.js
+++ b/src/Invoice/Asset/jquery-ui-1.14.0/external/jquery/jquery.js
@@ -1275,10 +1275,21 @@ function setDocument( node ) {
 
 		var input;
 
-		documentElement.appendChild( el ).innerHTML =
-			"<a id='" + expando + "' href='' disabled='disabled'></a>" +
-			"<select id='" + expando + "-\r\\' disabled='disabled'>" +
-			"<option selected=''></option></select>";
+		var anchor = document.createElement('a');
+		anchor.id = expando;
+		anchor.href = '';
+		anchor.setAttribute('disabled', 'disabled');
+		el.appendChild(anchor);
+
+		var select = document.createElement('select');
+		select.id = expando + "-\r\\";
+		select.setAttribute('disabled', 'disabled');
+
+		var option = document.createElement('option');
+		option.setAttribute('selected', '');
+		select.appendChild(option);
+
+		el.appendChild(select);
 
 		// Support: iOS <=7 - 8 only
 		// Boolean attributes and "value" are not treated correctly in some XML documents


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/invoice/security/code-scanning/148](https://github.com/rossaddison/invoice/security/code-scanning/148)

To fix the problem, we need to ensure that the HTML construction does not use untrusted data directly. Instead of using `innerHTML`, we can create the elements using safer methods like `createElement` and `setAttribute`. This approach avoids the risk of XSS by not directly injecting HTML strings.

- Replace the use of `innerHTML` with methods that safely create and append elements.
- Specifically, in the file `src/Invoice/Asset/jquery-ui-1.14.0/external/jquery/jquery.js`, modify the code to use `createElement` and `setAttribute` for constructing the HTML elements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
