### PR TITLE
Potential fix for code scanning alert no. 149: Unsafe jQuery plugin

### DIFF
--- a/src/Invoice/Asset/jquery-ui-1.14.0/jquery-ui.js
+++ b/src/Invoice/Asset/jquery-ui-1.14.0/jquery-ui.js
@@ -862,7 +862,7 @@ $.extend( Datepicker.prototype, {
 		}
 
 		isFixed = false;
-		$( input ).parents().each( function() {
+		$( $.find(input) ).parents().each( function() {
 			isFixed |= $( this ).css( "position" ) === "fixed";
 			return !isFixed;
 		} );


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/invoice/security/code-scanning/149](https://github.com/rossaddison/invoice/security/code-scanning/149)

To fix the problem, we need to ensure that the `input` element is properly sanitized before being used in a jQuery selector. This can be achieved by validating the `input` element to ensure it is a safe and expected HTML element. Additionally, we should avoid using jQuery selectors that can interpret strings as HTML.

The best way to fix the problem without changing existing functionality is to use a more secure method to handle the `input` element. Specifically, we can use `jQuery.find` to ensure that the `input` is always treated as a CSS selector and not as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
