### PR TITLE
Potential fix for code scanning alert no. 151: Unsafe jQuery plugin

### DIFF
--- a/src/Invoice/Asset/jquery-ui-1.14.0/jquery-ui.js
+++ b/src/Invoice/Asset/jquery-ui-1.14.0/jquery-ui.js
@@ -989,7 +989,7 @@ $.extend( Datepicker.prototype, {
 			obj = obj[ isRTL ? "previousSibling" : "nextSibling" ];
 		}
 
-		position = $( obj ).offset();
+		position = $.find( obj ).offset();
 		return [ position.left, position.top ];
 	},
 


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/invoice/security/code-scanning/151](https://github.com/rossaddison/invoice/security/code-scanning/151)

To fix the problem, we need to ensure that the `options` parameter is properly sanitized before being used in the `$.fn.datepicker` plugin. Specifically, we should avoid using jQuery's `$()` function with potentially untrusted input, as it can interpret the input as HTML. Instead, we can use safer methods to handle the input.

The best way to fix the problem without changing existing functionality is to modify the `_findPos` function to use a safer method for finding the position of the `obj` element. We can use `jQuery.find` to ensure that the input is always treated as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
