### PR TITLE
Potential fix for code scanning alert no. 191: Overly permissive regular expression range

### DIFF
--- a/Tests/_output/Tests.Functional.SiteControllerCest.testOneTimePasswordFailurePage.fail.html
+++ b/Tests/_output/Tests.Functional.SiteControllerCest.testOneTimePasswordFailurePage.fail.html
@@ -1762,7 +1762,7 @@ contains:[{begin:/\(\)/},S]
 match:[/const|var|let/,/\s+/,b,/\s*/,/=\s*/,/(async\s*)?/,l.lookahead(C)],
 keywords:"async",className:{1:"keyword",3:"title.function"},contains:[S]}
 ;return{name:"Javascript",aliases:["js","jsx","mjs","cjs"],keywords:g,exports:{
-PARAMS_CONTAINS:p,CLASS_REFERENCE:R},illegal:/#(?![$_A-z])/,
+PARAMS_CONTAINS:p,CLASS_REFERENCE:R},illegal:/#(?![$_A-Za-z])/,
 contains:[o.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
 label:"use_strict",className:"meta",relevance:10,
 begin:/^\s*['"]use (strict|asm)['"]/


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/invoice/security/code-scanning/191](https://github.com/rossaddison/invoice/security/code-scanning/191)

The fix is to tighten the regular expression range, changing `[$_A-z]` to `[$_A-Za-z]` in order to cover only uppercase and lowercase English letters in addition to `$` and `_`, which are commonly included in JavaScript identifiers. Update only the character class within the regular expression on the highlighted line (line 1765), making sure to not change any unrelated logic or behavior elsewhere in the file. No additional imports, definitions, or dependencies are necessary, as this is a syntactic regular expression fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
