### PR TITLE
Potential fix for code scanning alert no. 190: Overly permissive regular expression range

### DIFF
--- a/Tests/_output/Tests.Functional.SiteControllerCest.testOneTimePasswordSuccessPage.fail.html
+++ b/Tests/_output/Tests.Functional.SiteControllerCest.testOneTimePasswordSuccessPage.fail.html
@@ -1762,7 +1762,7 @@ contains:[{begin:/\(\)/},S]
 match:[/const|var|let/,/\s+/,b,/\s*/,/=\s*/,/(async\s*)?/,l.lookahead(C)],
 keywords:"async",className:{1:"keyword",3:"title.function"},contains:[S]}
 ;return{name:"Javascript",aliases:["js","jsx","mjs","cjs"],keywords:g,exports:{
-PARAMS_CONTAINS:p,CLASS_REFERENCE:R},illegal:/#(?![$_A-z])/,
+PARAMS_CONTAINS:p,CLASS_REFERENCE:R},illegal:/#(?![$_A-Za-z])/,
 contains:[o.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
 label:"use_strict",className:"meta",relevance:10,
 begin:/^\s*['"]use (strict|asm)['"]/


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/invoice/security/code-scanning/190](https://github.com/rossaddison/invoice/security/code-scanning/190)

The fix is to replace the problematic `A-z` range in the regex with the correct `A-Za-z` range, which will match only uppercase and lowercase ASCII letters. This ensures that only those characters are considered, and does not inadvertently include the special characters `[ \ ] ^ _ \``. In the file `Tests/_output/Tests.Functional.SiteControllerCest.testOneTimePasswordSuccessPage.fail.html`, locate the line with `illegal:/#(?![$_A-z])/` and replace it with `illegal:/#(?![$_A-Za-z])/`. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
