### PR TITLE
e.g.ini

### DIFF
--- a/e.g.ini/lamp/alpine/etc/php83/php.ini
+++ b/e.g.ini/lamp/alpine/etc/php83/php.ini
@@ -1440,7 +1440,7 @@ session.cookie_domain =
 ; Whether or not to add the httpOnly flag to the cookie, which makes it
 ; inaccessible to browser scripting languages such as JavaScript.
 ; https://php.net/session.cookie-httponly
-session.cookie_httponly =
+session.cookie_httponly = 1
 
 ; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
 ; Current valid values are "Strict", "Lax" or "None". When using "None",

--- a/e.g.ini/wamp/php8.4.15/cli/php.ini
+++ b/e.g.ini/wamp/php8.4.15/cli/php.ini
@@ -1350,7 +1350,7 @@ session.cookie_domain =
 ; Whether or not to add the httpOnly flag to the cookie, which makes it
 ; inaccessible to browser scripting languages such as JavaScript.
 ; https://php.net/session.cookie-httponly
-session.cookie_httponly =
+session.cookie_httponly = 1
 
 ; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
 ; Current valid values are "Strict", "Lax" or "None". When using "None",

--- a/e.g.ini/wamp/php8.5.0/cli/php.ini
+++ b/e.g.ini/wamp/php8.5.0/cli/php.ini
@@ -1364,7 +1364,7 @@ session.cookie_domain =
 ; Whether or not to add the httpOnly flag to the cookie, which makes it
 ; inaccessible to browser scripting languages such as JavaScript.
 ; https://php.net/session.cookie-httponly
-session.cookie_httponly =
+session.cookie_httponly = 1
 
 ; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
 ; Current valid values are "Strict", "Lax" or "None". When using "None",


### PR DESCRIPTION
 All three reference ini files now have session.cookie_httponly = 1. These files are also covered by the e.g.ini/** entry in sonar.exclusions, so once pushed they'll be excluded from future scans entirely — but setting the value correctly is better than relying solely on the exclusion.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
