### PR TITLE
Fix SonarQube S107: PeppolUblXml::xml() re-exceeded 7-parameter limit

### DIFF
--- a/Tests/Unit/Invoice/Libraries/PeppolUblXmlCreditNoteTest.php
+++ b/Tests/Unit/Invoice/Libraries/PeppolUblXmlCreditNoteTest.php
@@ -81,7 +81,7 @@ final class PeppolUblXmlCreditNoteTest extends TestCase
      *     financial: PeppolFinancialData,
      * }
      */
-    private function minimalDocumentGraph(SettingRepository $s): array
+    private function minimalDocumentGraph(SettingRepository $s, bool $isCreditNote = false): array
     {
         $header = new PeppolInvoiceHeader(
             'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
@@ -100,6 +100,7 @@ final class PeppolUblXmlCreditNoteTest extends TestCase
                 null,
                 true,
                 null,
+                $isCreditNote,
             ),
         );
 
@@ -156,14 +157,13 @@ final class PeppolUblXmlCreditNoteTest extends TestCase
     public function testCreditNoteOutputsCreditNoteRootTagNamespaceAndTypeCode(): void
     {
         $s = $this->settingRepository();
-        $graph = $this->minimalDocumentGraph($s);
+        $graph = $this->minimalDocumentGraph($s, isCreditNote: true);
         $party = $this->minimalParty();
         $peppolUblXml = new PeppolUblXml($s);
 
         $ubl = $peppolUblXml->xml(
             $graph['header'], $graph['additionalDocumentReference'],
             $party, $party, $graph['delivery'], $graph['payment'], $graph['financial'],
-            isCreditNote: true,
         );
         $xml = $peppolUblXml->output($ubl);
 

--- a/src/Invoice/Helpers/Peppol/PeppolHelper.php
+++ b/src/Invoice/Helpers/Peppol/PeppolHelper.php
@@ -362,6 +362,7 @@ class PeppolHelper
                 null !== $cdr_id ? new ContractDocumentReference($cdr_id) : null,
                 $isCopyIndicator,
                 $supplierAssignedAccountID,
+                $this->isCreditNote($invoice),
             ),
         );
         $peppolPayment = new PeppolPaymentData(
@@ -396,7 +397,6 @@ class PeppolHelper
             ),
             $peppolPayment,
             $peppolFinancial,
-            $this->isCreditNote($invoice),
         );
         fwrite($f, $peppol_ubl_xml->output($xml));
         fclose($f);

--- a/src/Invoice/Libraries/PeppolInvoiceReferences.php
+++ b/src/Invoice/Libraries/PeppolInvoiceReferences.php
@@ -14,6 +14,7 @@ readonly class PeppolInvoiceReferences
         public ?ContractDocumentReference $contractDocumentReference,
         public ?bool $isCopyIndicator,
         public ?string $supplierAssignedAccountID,
+        public ?bool $isCreditNote = false,
     ) {
     }
 }

--- a/src/Invoice/Libraries/PeppolUblXml.php
+++ b/src/Invoice/Libraries/PeppolUblXml.php
@@ -22,9 +22,9 @@ final readonly class PeppolUblXml
         Delivery $delivery,
         PeppolPaymentData $payment,
         PeppolFinancialData $financial,
-        bool $isCreditNote = false,
     ): Invoice {
-        $documentClass = $isCreditNote ? CreditNote::class : Invoice::class;
+        $documentClass = ($header->references->isCreditNote ?? false)
+            ? CreditNote::class : Invoice::class;
         return new $documentClass(
             $this->sR,
             $header->profileID,


### PR DESCRIPTION
## Summary

`main`'s credit-note fix (51d67458, merged into #998 via 8773fb0b) added an
8th `bool $isCreditNote` parameter to `PeppolUblXml::xml()`, re-tripping the
SonarQube S107 7-parameter limit that had already been fixed on this branch.

Moves the flag onto `PeppolInvoiceReferences` (which already carries the
sibling `isCopyIndicator` flag) instead of threading it through `xml()` as a
bare argument — `xml()` is back to 7 parameters, and the flag is read via
`$header->references->isCreditNote` inside the method.

## Changes
- `PeppolInvoiceReferences`: add `?bool $isCreditNote = false`
- `PeppolUblXml::xml()`: drop the parameter, read from `$header->references->isCreditNote`
- `PeppolHelper::generateInvoicePeppolUblXmlTempFile()`: pass the flag into `PeppolInvoiceReferences` instead of `xml()`
- `Tests/Unit/Invoice/Libraries/PeppolUblXmlCreditNoteTest.php`: updated to match

## Test plan
- [x] `vendor/bin/psalm --no-cache` on all touched files — zero errors
- [x] `vendor/bin/phpunit Tests/Unit/Invoice/Libraries/PeppolUblXmlCreditNoteTest.php` — both tests pass (pre-existing PHPUnit notices only)
- [x] `vendor/bin/testo --suite=Unit` (full suite) — 569/572 passing; the 3 errors are pre-existing `AmazonPayPaymentServiceTest` RSA-key-generation failures on this machine, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Peppol document generation to more reliably identify and produce credit notes, helping ensure the correct document type is delivered.

* **Refactor**
  * Streamlined how credit-note information is handled during invoice generation without changing the resulting user-facing workflow.

* **Tests**
  * Updated automated coverage to validate credit-note generation using the revised handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->