### PR TITLE
Fix inv/index rendering empty — wire DwellingRepository into non-HTMX widget path

### DIFF
--- a/resources/views/invoice/inv/index.php
+++ b/resources/views/invoice/inv/index.php
@@ -11,6 +11,7 @@ use Yiisoft\Html\Html as H;
 /**
  * @var App\Invoice\CategorySecondary\CategorySecondaryRepository $csR
  * @var App\Invoice\DeliveryLocation\DeliveryLocationRepository $dlR
+ * @var App\Invoice\Dwelling\DwellingRepository $dwR
  * @var App\Invoice\Inv\InvRepository $iR
  * @var App\Invoice\InvRecurring\InvRecurringRepository $irR
  * @var App\Invoice\InvSentLog\InvSentLogRepository $islR
@@ -178,6 +179,7 @@ echo InvsListWidget::widget()
     ->withEmailRepositories($etR, $fdR)
     ->withWorkerRepository($wR)
     ->withCategorySecondaryRepository($csR)
+    ->withDwellingRepository($dwR)
     ->withCsrf($csrf)
     ->withDecimalPlaces($decimalPlaces)
     ->withVisible($visible)

--- a/src/Invoice/Inv/Trait/Index.php
+++ b/src/Invoice/Inv/Trait/Index.php
@@ -113,6 +113,7 @@ public function index(
                 'soR'                => $nav->soR,
                 'wR'                 => $nav->wR,
                 'csR'                => $nav->csR,
+                'dwR'                => $nav->dwR,
                 'sortString'         => $sortString,
                 'status'             => $effectiveStatus,
                 'visible'            => $visible !== '0',


### PR DESCRIPTION
## Root cause

`InvsListWidget::render()` gained a hard null-guard on `$this->dwR` when the HomeCare house-number column was added in the Dwelling redesign, but `->withDwellingRepository()` was only ever wired into the **HTMX partial-refresh** branch in `Trait/Index.php`. The separate, full-page-load widget construction in `resources/views/invoice/inv/index.php` never received a `DwellingRepository` at all — so every normal (non-HTMX) visit to `inv/index` hit the null-guard and rendered `''` for the entire grid.

This is what caused **inv/index to appear completely removed**, both locally and on yii3i.online.

## Fix

- `src/Invoice/Inv/Trait/Index.php` — add `'dwR' => $nav->dwR` to the `$parameters` array passed to the non-HTMX `render()` call.
- `resources/views/invoice/inv/index.php` — declare `@var $dwR`, add `->withDwellingRepository($dwR)` to the widget chain (matching the already-correct HTMX branch).

## Verification

- `php -l` on both changed files
- Full-project `vendor/bin/psalm --no-cache` — no errors
- Full PHPUnit suite — 3896 tests, 0 failures
- Full Testo suite — 828 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the invoice listing view’s integration with dwelling information.
  * Invoice navigation now receives the data needed to support more complete dwelling-related invoice details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->