### PR TITLE
Fix 11 SonarQube code smells (S1142, S2010, S3776, S3358 x5, S1448 x2)

### DIFF
--- a/Tests/Testo/Invoice/Product/ProductServiceFindOrCreateHouseNumberTest.php
+++ b/Tests/Testo/Invoice/Product/ProductServiceFindOrCreateHouseNumberTest.php
@@ -10,6 +10,7 @@ use App\Infrastructure\Persistence\TaxRate\TaxRate;
 use App\Infrastructure\Persistence\Unit\Unit;
 use App\Invoice\Enum\ProductType;
 use App\Invoice\Family\FamilyRepository;
+use App\Invoice\Product\ProductNameTypeRepository;
 use App\Invoice\Product\ProductRepository;
 use App\Invoice\Product\ProductService;
 use App\Invoice\TaxRate\TaxRateRepository;
@@ -53,11 +54,12 @@ final class ProductServiceFindOrCreateHouseNumberTest
         $e->once()->with('12', 5)->andReturn($this->readerYielding([$existing]));
         $productR->shouldNotReceive('save');
 
+        $nameTypeR = m::mock(ProductNameTypeRepository::class);
         $fR = m::mock(FamilyRepository::class);
         $trR = m::mock(TaxRateRepository::class);
         $unR = m::mock(UnitRepository::class);
 
-        $service = new ProductService($productR, $fR, $trR, $unR);
+        $service = new ProductService($productR, $nameTypeR, $fR, $trR, $unR);
 
         Assert::same(
             $existing,
@@ -94,7 +96,8 @@ final class ProductServiceFindOrCreateHouseNumberTest
         $e5 = $unR->shouldReceive('repoUnitquery');
         $e5->andReturn(m::mock(Unit::class));
 
-        $service = new ProductService($productR, $fR, $trR, $unR);
+        $nameTypeR = m::mock(ProductNameTypeRepository::class);
+        $service = new ProductService($productR, $nameTypeR, $fR, $trR, $unR);
         $product = $service->findOrCreateHouseNumberProduct(5, '14', 35.00, 2, 3);
 
         Assert::same('14', $product->getProductName());
@@ -112,11 +115,12 @@ final class ProductServiceFindOrCreateHouseNumberTest
         $e = $productR->expects('delete');
         $e->once()->with($product);
 
+        $nameTypeR = m::mock(ProductNameTypeRepository::class);
         $fR = m::mock(FamilyRepository::class);
         $trR = m::mock(TaxRateRepository::class);
         $unR = m::mock(UnitRepository::class);
 
-        $service = new ProductService($productR, $fR, $trR, $unR);
+        $service = new ProductService($productR, $nameTypeR, $fR, $trR, $unR);
         $service->deleteProduct($product);
     }
 }

--- a/config/common/di/cycle.php
+++ b/config/common/di/cycle.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 use App\Infrastructure\Persistence\As4Message\As4Message;
 use App\Infrastructure\Persistence\As4Message\CycleOrmAs4MessageRepository;
+use App\Infrastructure\Persistence\Client\Client;
+use App\Infrastructure\Persistence\Product\Product;
 use App\Infrastructure\Persistence\UserRbacLink\UserRbacLink;
+use App\Invoice\Client\ClientDwellingRepository;
+use App\Invoice\Product\ProductNameTypeRepository;
 use App\Invoice\UserInv\UserRbacLinkRepository;
 use Cycle\Database\DatabaseInterface;
 use Cycle\Database\DatabaseManager;
@@ -54,5 +58,19 @@ return [
             $writer,
             $db,
         );
+    },
+
+    // ClientDwellingRepository is not Client's Cycle-ORM-designated repository (that's still
+    // ClientRepository, per Client's own #[Entity(repository: ...)] attribute), so it needs the same
+    // explicit Select<Client> wiring as CycleOrmAs4MessageRepository above — split out purely to keep
+    // ClientRepository under SonarQube's php:S1448 method-count ceiling.
+    ClientDwellingRepository::class => static function (ORMInterface $orm): ClientDwellingRepository {
+        return new ClientDwellingRepository(new Select($orm, Client::class));
+    },
+
+    // Same reasoning as ClientDwellingRepository above — split out purely to keep ProductRepository
+    // under SonarQube's php:S1448 method-count ceiling.
+    ProductNameTypeRepository::class => static function (ORMInterface $orm): ProductNameTypeRepository {
+        return new ProductNameTypeRepository(new Select($orm, Product::class));
     },
 ];

--- a/src/Auth/Controller/HomeCareSignupController.php
+++ b/src/Auth/Controller/HomeCareSignupController.php
@@ -248,23 +248,13 @@ final class HomeCareSignupController
         }
         ['identity' => $identity, 'userId' => $userId, 'pending' => $pending, 'userInv' => $userInv] = $resolved;
 
-        $dwellingResult = $this->resolveDwellingForSignup($pending, $d);
-        if ($dwellingResult instanceof Response) {
-            return $dwellingResult;
+        $finished = $this->resolveDwellingAndProvisionInvoice(
+            $identity, $userId, $language, $pending, $userInv, $formHydrator, $d,
+        );
+        if ($finished instanceof Response) {
+            return $finished;
         }
-        ['dwelling' => $dwelling, 'taxRate' => $taxRate, 'unit' => $unit] = $dwellingResult;
-
-        $email = $identity->getUser()?->getEmail() ?? '';
-        $client = $this->createClient($email, $language, $pending, $dwelling, $d);
-        $clientId = $client->reqId();
-        $this->linkUserClient($userId, $clientId, $d);
-        $this->assignSignupRole($userId, $userInv->reqId(), $d);
-
-        $provisioned = $this->provisionInvoice($clientId, $dwelling, $taxRate, $unit, $pending, $formHydrator, $d);
-        if ($provisioned instanceof Response) {
-            return $provisioned;
-        }
-        $invId = $provisioned;
+        ['client' => $client, 'invId' => $invId] = $finished;
 
         $paidNow = false;
         if ($pending->getPaymentOption() === HomeCareSignupForm::PAYMENT_HAVE_PAID_CASH) {
@@ -426,6 +416,45 @@ final class HomeCareSignupController
             return $this->renderConfirmed('setup_incomplete');
         }
         return ['dwelling' => $dwelling, 'taxRate' => $taxRate, 'unit' => $unit];
+    }
+
+    /**
+     * Resolves the Dwelling, creates and links the Client, and provisions
+     * the first invoice — split out of confirm() purely to keep its own
+     * return count within SonarQube's limit (S1142), following the same
+     * pattern already used for resolveIdentityFromToken()/
+     * resolveAndActivateSignup(): each failure branch here happens before
+     * any side effect the other doesn't already account for, so merging
+     * them into one guard in the caller costs nothing.
+     *
+     * @return Response|array{client: Client, invId: int}
+     */
+    private function resolveDwellingAndProvisionInvoice(
+        Identity $identity,
+        int $userId,
+        string $language,
+        HomeCarePendingSignup $pending,
+        UserInv $userInv,
+        FormHydrator $formHydrator,
+        HomeCareSignupConfirmDeps $d,
+    ): Response|array {
+        $dwellingResult = $this->resolveDwellingForSignup($pending, $d);
+        if ($dwellingResult instanceof Response) {
+            return $dwellingResult;
+        }
+        ['dwelling' => $dwelling, 'taxRate' => $taxRate, 'unit' => $unit] = $dwellingResult;
+
+        $email = $identity->getUser()?->getEmail() ?? '';
+        $client = $this->createClient($email, $language, $pending, $dwelling, $d);
+        $clientId = $client->reqId();
+        $this->linkUserClient($userId, $clientId, $d);
+        $this->assignSignupRole($userId, $userInv->reqId(), $d);
+
+        $provisioned = $this->provisionInvoice($clientId, $dwelling, $taxRate, $unit, $pending, $formHydrator, $d);
+        if ($provisioned instanceof Response) {
+            return $provisioned;
+        }
+        return ['client' => $client, 'invId' => $provisioned];
     }
 
     /**

--- a/src/Invoice/Client/ClientDwellingRepository.php
+++ b/src/Invoice/Client/ClientDwellingRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Invoice\Client;
+
+use App\Infrastructure\Persistence\Client\Client;
+use Cycle\ORM\Select;
+
+/**
+ * Client-Dwelling relationship query, split out of ClientRepository purely to keep that class under
+ * SonarQube's php:S1448 method-count ceiling (20 methods) — the same reasoning already documented for
+ * MolliePaymentController/PaystackPaymentController splitting out of PaymentInformationController. Not
+ * Client's Cycle-ORM-designated repository (that's still ClientRepository, per Client's own
+ * #[Entity(repository: ...)] attribute) — wired explicitly in config/common/di/cycle.php, following the
+ * same explicit-Select pattern already used for CycleOrmAs4MessageRepository.
+ *
+ * @template TEntity of Client
+ * @extends Select\Repository<TEntity>
+ */
+final class ClientDwellingRepository extends Select\Repository
+{
+    /**
+     * @param Select<TEntity> $select
+     */
+    public function __construct(Select $select)
+    {
+        parent::__construct($select);
+    }
+
+    /**
+     * Every dwelling_id currently claimed by a Client — the "already occupied" side of the worker
+     * canvassing dropdown's unclaimed-Dwelling anti-join, composed at the service layer
+     * ({@see \App\Invoice\Dwelling\DwellingService::repoUnclaimedDwellings()}).
+     *
+     * @return list<int>
+     */
+    public function repoClaimedDwellingIds(): array
+    {
+        $query = $this->select()
+            ->where(['dwelling_id' => ['not' => null]]);
+        $ids = [];
+        /** @var Client $client */
+        foreach ($query as $client) {
+            $dwellingId = $client->getDwellingId();
+            if ($dwellingId !== null) {
+                $ids[] = $dwellingId;
+            }
+        }
+        return $ids;
+    }
+}

--- a/src/Invoice/Client/ClientRepository.php
+++ b/src/Invoice/Client/ClientRepository.php
@@ -143,26 +143,6 @@ final class ClientRepository extends Select\Repository implements ClientReposito
     }
 
     /**
-     * Every dwelling_id currently claimed by a Client — the "already occupied" side of the worker
-     * canvassing dropdown's unclaimed-Dwelling anti-join, composed at the service layer
-     * ({@see \App\Invoice\Dwelling\DwellingService::repoUnclaimedDwellings()}).
-     *
-     * @return list<int>
-     */
-    public function repoClaimedDwellingIds(): array
-    {
-        $query = $this->select()
-            ->where(['dwelling_id' => ['not' => null]]);
-        $ids = [];
-        /** @var Client $client */
-        foreach ($query as $client) {
-            $dwellingId = $client->getDwellingId();
-            $dwellingId === null or $ids[] = $dwellingId;
-        }
-        return $ids;
-    }
-
-    /**
      * @psalm-return EntityReader
      */
     public function repoUserClient(array $available_client_id_list): EntityReader

--- a/src/Invoice/Dwelling/DwellingService.php
+++ b/src/Invoice/Dwelling/DwellingService.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace App\Invoice\Dwelling;
 
 use App\Infrastructure\Persistence\Dwelling\Dwelling;
-use App\Invoice\Client\ClientRepository;
+use App\Invoice\Client\ClientDwellingRepository;
 use Yiisoft\Data\Cycle\Reader\EntityReader;
 
 final readonly class DwellingService
 {
     public function __construct(
         private DwellingRepository $repository,
-        private ClientRepository $clientRepository,
+        private ClientDwellingRepository $clientDwellingRepository,
     ) {
     }
 
@@ -22,15 +22,35 @@ final readonly class DwellingService
      */
     public function saveDwelling(Dwelling $model, array $array): void
     {
+        $this->applyDwellingIdentityFields($model, $array);
+        $this->applyDwellingLocationFields($model, $array);
+        $this->repository->save($model);
+    }
+
+    private function applyDwellingIdentityFields(Dwelling $model, array $array): void
+    {
         isset($array['family_id']) ? $model->setFamilyId((int) $array['family_id']) : '';
         isset($array['house_number_numeric']) ? $model->setHouseNumberNumeric((int) $array['house_number_numeric']) : '';
-        isset($array['house_number_suffix']) ? $model->setHouseNumberSuffix($array['house_number_suffix'] === '' ? null : (string) $array['house_number_suffix']) : '';
-        isset($array['flat_unit']) ? $model->setFlatUnit($array['flat_unit'] === '' ? null : (string) $array['flat_unit']) : '';
+        isset($array['house_number_suffix']) ? $model->setHouseNumberSuffix(self::nullableString($array['house_number_suffix'])) : '';
+        isset($array['flat_unit']) ? $model->setFlatUnit(self::nullableString($array['flat_unit'])) : '';
+    }
+
+    private function applyDwellingLocationFields(Dwelling $model, array $array): void
+    {
         isset($array['postcode']) ? $model->setPostcode((string) $array['postcode']) : '';
-        isset($array['latitude']) ? $model->setLatitude($array['latitude'] === '' ? null : (float) $array['latitude']) : '';
-        isset($array['longitude']) ? $model->setLongitude($array['longitude'] === '' ? null : (float) $array['longitude']) : '';
-        isset($array['source']) ? $model->setSource($array['source'] === '' ? null : (string) $array['source']) : '';
-        $this->repository->save($model);
+        isset($array['latitude']) ? $model->setLatitude(self::nullableFloat($array['latitude'])) : '';
+        isset($array['longitude']) ? $model->setLongitude(self::nullableFloat($array['longitude'])) : '';
+        isset($array['source']) ? $model->setSource(self::nullableString($array['source'])) : '';
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        return $value === '' ? null : (string) $value;
+    }
+
+    private static function nullableFloat(mixed $value): ?float
+    {
+        return $value === '' ? null : (float) $value;
     }
 
     public function deleteDwelling(Dwelling $model): void
@@ -49,7 +69,7 @@ final readonly class DwellingService
     {
         return $this->repository->repoUnclaimedByFamilyIdQuery(
             $familyId,
-            $this->clientRepository->repoClaimedDwellingIds(),
+            $this->clientDwellingRepository->repoClaimedDwellingIds(),
         );
     }
 

--- a/src/Invoice/Product/ProductNameTypeRepository.php
+++ b/src/Invoice/Product/ProductNameTypeRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Invoice\Product;
+
+use App\Infrastructure\Persistence\Product\Product;
+use Cycle\ORM\Select;
+
+/**
+ * Exact-match Product lookup by product_name + product_type, split out of ProductRepository purely to
+ * keep that class under SonarQube's php:S1448 method-count ceiling (20 methods) — the same reasoning
+ * already documented for ClientDwellingRepository splitting out of ClientRepository. Not Product's
+ * Cycle-ORM-designated repository (that's still ProductRepository, per Product's own
+ * #[Entity(repository: ...)] attribute) — wired explicitly in config/common/di/cycle.php, following the
+ * same explicit-Select pattern already used for CycleOrmAs4MessageRepository.
+ *
+ * @template TEntity of Product
+ * @extends Select\Repository<TEntity>
+ */
+final class ProductNameTypeRepository extends Select\Repository
+{
+    /**
+     * @param Select<TEntity> $select
+     */
+    public function __construct(Select $select)
+    {
+        parent::__construct($select);
+    }
+
+    /**
+     * Exact match on product_name + product_type, unscoped by family — used to find-or-create the single
+     * shared Service-type Product a HomeCare invoice line references (see
+     * {@see \App\Invoice\Product\ProductService::findOrCreateHomeCareServiceProduct()}), where family_id
+     * is a structural FK requirement only (Product.family's BelongsTo is nullable: false) and carries no
+     * semantic meaning for this particular Product — unlike ProductRepository::repoProductWithFamilyIdQuery(),
+     * which is deliberately family-scoped for the (unrelated) commalist bulk-generation dedup check.
+     *
+     * @return Product|null
+     *
+     * @psalm-return TEntity|null
+     */
+    public function repoProductByNameAndTypeQuery(string $product_name, string $product_type): ?Product
+    {
+        $query = $this
+            ->select()
+            ->where(['product_name' => $product_name])
+            ->andWhere(['product_type' => $product_type]);
+        return $query->fetchOne() ?: null;
+    }
+}

--- a/src/Invoice/Product/ProductRepository.php
+++ b/src/Invoice/Product/ProductRepository.php
@@ -199,27 +199,6 @@ final class ProductRepository extends Select\Repository implements ProductReposi
     }
 
     /**
-     * Exact match on product_name + product_type, unscoped by family — used to find-or-create the single
-     * shared Service-type Product a HomeCare invoice line references (see
-     * {@see \App\Invoice\Product\ProductService::findOrCreateHomeCareServiceProduct()}), where family_id
-     * is a structural FK requirement only (Product.family's BelongsTo is nullable: false) and carries no
-     * semantic meaning for this particular Product — unlike repoProductWithFamilyIdQuery(), which is
-     * deliberately family-scoped for the (unrelated) commalist bulk-generation dedup check.
-     *
-     * @return Product|null
-     *
-     * @psalm-return TEntity|null
-     */
-    public function repoProductByNameAndTypeQuery(string $product_name, string $product_type): ?Product
-    {
-        $query = $this
-            ->select()
-            ->where(['product_name' => $product_name])
-            ->andWhere(['product_type' => $product_type]);
-        return $query->fetchOne() ?: null;
-    }
-
-    /**
      * Get products with filter using views/invoice/product/modal_product_lookups_inv or ...quote
      * Excludes zero-valued products for invoice/quote selection
      *

--- a/src/Invoice/Product/ProductService.php
+++ b/src/Invoice/Product/ProductService.php
@@ -21,6 +21,7 @@ final readonly class ProductService
 
     public function __construct(
         private ProductRepository $repository,
+        private ProductNameTypeRepository $nameTypeRepository,
         private FR $fR,
         private TRR $trR,
         private UR $uR,
@@ -189,7 +190,7 @@ final readonly class ProductService
      */
     public function findOrCreateHomeCareServiceProduct(int $familyId, int $taxRateId, int $unitId): Product
     {
-        $existing = $this->repository->repoProductByNameAndTypeQuery(
+        $existing = $this->nameTypeRepository->repoProductByNameAndTypeQuery(
             self::HOMECARE_SERVICE_PRODUCT_NAME,
             ProductType::Service->value,
         );

--- a/src/Invoice/Setting/Console/CheckGatewaySecretsCommand.php
+++ b/src/Invoice/Setting/Console/CheckGatewaySecretsCommand.php
@@ -68,33 +68,61 @@ final class CheckGatewaySecretsCommand extends Command
         /** @var array<string, array<string, array{type: string, label: string}>> $gateways */
         $gateways = $this->sR->activePaymentGateways();
         foreach ($gateways as $driver => $fields) {
-            $d = strtolower($driver);
             foreach ($fields as $key => $setting) {
-                if ($setting['type'] !== 'password') {
+                $result = $this->checkGatewaySecret($driver, $key, $setting, $io);
+                if ($result === null) {
                     continue;
                 }
-                $stored = $this->sR->getSetting('gateway_' . $d . '_' . $key);
-                if ($stored === '') {
-                    continue; // never configured — not this regression's concern
-                }
-
                 $checked++;
-                $label = "{$driver}.{$key}";
-                try {
-                    $decoded = (string) $this->sR->decode($stored);
-                    if ($decoded === '' || !mb_check_encoding($decoded, 'UTF-8')) {
-                        $corrupted[] = $label;
-                        $io->writeln("{$label}: CORRUPTED (decodes to empty/non-UTF8)");
-                        continue;
-                    }
-                    $io->writeln("{$label}: ok");
-                } catch (CryptorException $e) {
-                    $corrupted[] = $label;
-                    $io->writeln("{$label}: CORRUPTED ({$e->getMessage()})");
+                if ($result !== '') {
+                    $corrupted[] = $result;
                 }
             }
         }
 
+        return $this->reportResults($io, $checked, $corrupted);
+    }
+
+    /**
+     * Checks a single driver/field's stored secret, writing its result line to $io whenever it was
+     * actually a configured password secret. Split out of execute() purely to keep its cognitive
+     * complexity within SonarQube's limit (php:S3776).
+     *
+     * @param array{type: string, label: string} $setting
+     *
+     * @return string|null null when this field isn't a configured password secret at all (skipped, not
+     *   counted); '' when checked and fine; the corrupted label when checked and corrupted.
+     */
+    private function checkGatewaySecret(string $driver, string $key, array $setting, SymfonyStyle $io): ?string
+    {
+        if ($setting['type'] !== 'password') {
+            return null;
+        }
+        $stored = $this->sR->getSetting('gateway_' . strtolower($driver) . '_' . $key);
+        if ($stored === '') {
+            return null; // never configured — not this regression's concern
+        }
+
+        $label = "{$driver}.{$key}";
+        try {
+            $decoded = (string) $this->sR->decode($stored);
+            if ($decoded === '' || !mb_check_encoding($decoded, 'UTF-8')) {
+                $io->writeln("{$label}: CORRUPTED (decodes to empty/non-UTF8)");
+                return $label;
+            }
+            $io->writeln("{$label}: ok");
+            return '';
+        } catch (CryptorException $e) {
+            $io->writeln("{$label}: CORRUPTED ({$e->getMessage()})");
+            return $label;
+        }
+    }
+
+    /**
+     * @param list<string> $corrupted
+     */
+    private function reportResults(SymfonyStyle $io, int $checked, array $corrupted): int
+    {
         $io->writeln("Checked {$checked} configured secret(s).");
         if ($corrupted !== []) {
             $io->error(


### PR DESCRIPTION
Addresses all 11 SonarQube findings from the HomeCare Dwelling redesign PR.

| Rule | File | Fix |
|---|---|---|
| php:S1142 (4 returns > 3) | `HomeCareSignupController.php:235` | Extracted `resolveDwellingAndProvisionInvoice()` out of `confirm()`, merging two guard-returns into one, following the same pattern already used for `resolveAndActivateSignup()`/`resolveIdentityFromToken()` in this file |
| php:S2010 (`or` as control flow) | `ClientRepository.php:160` | Replaced with a plain `if` |
| php:S3776 (complexity 18 > 15) + php:S3358 x5 (nested ternaries) | `DwellingService.php:23-32` | Split `saveDwelling()` into `applyDwellingIdentityFields()`/`applyDwellingLocationFields()` + `nullableString()`/`nullableFloat()` helpers, eliminating every nested ternary |
| php:S3776 (complexity 17 > 15) | `CheckGatewaySecretsCommand.php:60` | Extracted `checkGatewaySecret()` (per-field decode/report) and `reportResults()` (summary) out of `execute()` |
| php:S1448 x2 (21 methods > 20) | `ClientRepository.php:20`, `ProductRepository.php:21` | Split the newest method off each into a small companion repository — `ClientDwellingRepository::repoClaimedDwellingIds()` and `ProductNameTypeRepository::repoProductByNameAndTypeQuery()` — wired via explicit `Select<Entity>` factories in `config/common/di/cycle.php`, following the existing `CycleOrmAs4MessageRepository` precedent. Both repositories back to 20 methods |

`DwellingService`/`ProductService` updated to depend on the new companion repositories; `ProductServiceFindOrCreateHouseNumberTest` updated for `ProductService`'s new constructor parameter.

## Verification
- `php -l` on every changed/new file
- Full-project `vendor/bin/psalm --no-cache` — no errors
- Full PHPUnit suite — 3896 tests, 0 failures
- Full Testo suite — 828 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)