### PR TITLE
Fix inv/index Current Run filter dropdown missing its accent border

### DIFF
--- a/src/Invoice/Asset/invoice/css/components.css
+++ b/src/Invoice/Asset/invoice/css/components.css
@@ -492,14 +492,15 @@ textarea.form-control {
     font-weight: 500;
 }
 
-#filter-inv-number        { border-left-color: #0d6efd; }
-#filter-credit-inv-number { border-left-color: #6610f2; }
-#filter-family-name       { border-left-color: #6f42c1; }
-#filter-year-month        { border-left-color: #fd7e14; }
-#filter-status            { border-left-color: #198754; }
-#filter-client            { border-left-color: #0dcaf0; }
-#filter-client-group      { border-left-color: #dc3545; }
-#filter-address-1         { border-left-color: #d63384; }
+#filter-inv-number             { border-left-color: #0d6efd; }
+#filter-credit-inv-number      { border-left-color: #6610f2; }
+#filter-family-name            { border-left-color: #6f42c1; }
+#filter-year-month             { border-left-color: #fd7e14; }
+#filter-status                 { border-left-color: #198754; }
+#filter-client                 { border-left-color: #0dcaf0; }
+#filter-client-group           { border-left-color: #dc3545; }
+#filter-address-1              { border-left-color: #d63384; }
+#filter-category-secondary-run { border-left-color: #6c757d; }
 
 .inv-footer-label {
     display: block;


### PR DESCRIPTION
## Root cause

Every filter dropdown in `inv/index` gets a colored left-accent border via a per-`id` CSS rule layered on top of the shared `.inv-filter` base class (which defaults to `border-left: 4px solid transparent`). `#filter-category-secondary-run` — the "Current Run" HomeCare filter — was the one filter that never got its own `border-left-color` rule, so it rendered with a transparent border while every other filter had its own distinct color. That's the inconsistency reported.

## Fix

Added the missing rule in `components.css`, using Bootstrap's `secondary` gray (`#6c757d`) — the one semantic accent color not already claimed by another filter.

No PHP changed; this is a CSS-only fix, published automatically by Yii3's content-hashed AssetManager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)