### PR TITLE
Add PHP 8.6 to the version-links dropdown

### DIFF
--- a/resources/views/layout/invoice.php
+++ b/resources/views/layout/invoice.php
@@ -833,6 +833,10 @@ if ((null !== $currentPath) && !$isGuest) {
                     'https://php.watch/versions/8.5',
                     $debugMode, false, itemAttributes: $itemFontArray +
                     ['style' => 'background-color: #ffcccb']),
+                DropdownItem::link('8.6',
+                    'https://php.watch/versions/8.6',
+                    $debugMode, false, itemAttributes: $itemFontArray +
+                    ['style' => 'background-color: #ffcccb']),
             ),
             // Emojipedia.org
             Dropdown::widget()


### PR DESCRIPTION
Small layout tweak — adds a PHP 8.6 entry to the version-links dropdown in the main layout, following the exact existing pattern already used for the 8.3/8.4/8.5 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)