### PR TITLE
Fix 4 more SonarQube code smells (S1185 x2, S1142, S1448)

### DIFF
--- a/src/Auth/Controller/HomeCareSignupController.php
+++ b/src/Auth/Controller/HomeCareSignupController.php
@@ -6,6 +6,7 @@ namespace App\Auth\Controller;
 
 use App\Auth\AuthService;
 use App\Auth\Form\HomeCareSignupForm;
+use App\Auth\HomeCareSignupEmailService;
 use App\Auth\Trait\ClassList;
 use App\Auth\Trait\TurnstileVerification;
 use App\Infrastructure\Persistence\CategorySecondary\CategorySecondary;
@@ -17,7 +18,6 @@ use App\Infrastructure\Persistence\Inv\Inv;
 use App\Infrastructure\Persistence\InvItem\InvItem;
 use App\Infrastructure\Persistence\Payment\Payment;
 use App\Infrastructure\Persistence\TaxRate\TaxRate;
-use App\Infrastructure\Persistence\Token\Token;
 use App\Infrastructure\Persistence\Unit\Unit;
 use App\Infrastructure\Persistence\User\User;
 use App\Infrastructure\Persistence\UserClient\UserClient;
@@ -32,12 +32,7 @@ use App\Service\WebControllerService;
 use App\User\UserRepository as UR;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Log\LoggerInterface;
 use Yiisoft\FormModel\FormHydrator;
-use Yiisoft\Html\Tag\A;
-use Yiisoft\Html\Tag\Body;
-use Yiisoft\Mailer\Message;
-use Yiisoft\Mailer\MailerInterface;
 use Yiisoft\Rbac\Manager;
 use Yiisoft\Router\CurrentRoute;
 use Yiisoft\Router\FastRoute\UrlGenerator;
@@ -71,11 +66,10 @@ final class HomeCareSignupController
         private readonly AuthService $authService,
         private readonly WebControllerService $webService,
         private WebViewRenderer $webViewRenderer,
-        private readonly MailerInterface $mailer,
+        private readonly HomeCareSignupEmailService $emailService,
         private readonly sR $sR,
         private readonly Translator $translator,
         private readonly UrlGenerator $urlGenerator,
-        private readonly LoggerInterface $logger,
     ) {
         $this->webViewRenderer = $webViewRenderer->withControllerName('homecaresignup');
     }
@@ -105,8 +99,8 @@ final class HomeCareSignupController
             $user = $signupForm->signup();
             $userId = $user->reqId();
             if ($userId > 0) {
-                $this->savePendingSignup($userId, $signupForm, $d);
-                $redirect = $this->processSendSignupEmail($user, $currentRoute, $d);
+                $this->emailService->savePendingSignup($userId, $signupForm, $d);
+                $redirect = $this->emailService->processSendSignupEmail($user, $currentRoute, $d);
             }
             $redirect = $redirect ?? $this->webService->getRedirectResponse('site/signupsuccess');
         }
@@ -126,110 +120,6 @@ final class HomeCareSignupController
             'categorySecondaryOptions' => $categorySecondaryOptions,
             'turnstileSiteKey' => $this->sR->getSetting('turnstile_site_key'),
         ]);
-    }
-
-    private function savePendingSignup(int $userId, HomeCareSignupForm $signupForm, HomeCareSignupDeps $d): void
-    {
-        $pending = new HomeCarePendingSignup();
-        $pending->setUserId($userId);
-        $pending->setClientName($signupForm->getClientName());
-        $pending->setClientSurname($signupForm->getClientSurname());
-        $pending->setStreet($signupForm->getStreet());
-        $pending->setBuildingNumber($signupForm->getBuildingNumber());
-        $pending->setPrice((float) $signupForm->getPrice());
-        $pending->setPaymentOption($signupForm->getPaymentOption());
-        $pending->setSecondaryCategoryId($signupForm->getSecondaryCategoryId());
-        $d->pendingR->save($pending);
-    }
-
-    private function processSendSignupEmail(
-        User $user,
-        CurrentRoute $currentRoute,
-        HomeCareSignupDeps $d,
-    ): ?Response {
-        $to = $user->getEmail();
-        $login = $user->getLogin();
-        $languageArray = $this->sR->localeLanguageArray();
-        $_language = $currentRoute->getArgument('_language');
-        /**
-         * @var string $_language
-         * @var string $language
-         */
-        $language = $languageArray[$_language];
-        $randomAndTimeToken = $this->getEmailVerificationToken($user, $d);
-        $htmlBody = $this->htmlBodyWithMaskedRandomAndTimeTokenLink(
-            $user, $d->uiR, $language, $_language, $randomAndTimeToken);
-        if (($this->sR->getSetting('email_send_method') == 'symfony')
-                || ($this->sR->mailerEnabled())) {
-            $configEmail = $this->sR->getConfigAdminEmail();
-            $tta = $this->translator->translate('administrator');
-            $email = new Message(
-                charset: 'utf-8',
-                headers: [
-                    'X-Origin' => ['0', '1'],
-                    'X-Pass' => 'pass',
-                ],
-                subject: $login . ': <' . $to . '>',
-                date: new \DateTimeImmutable('now'),
-                from: [$configEmail => $tta],
-                to: $to,
-                htmlBody: $htmlBody,
-            );
-            $email->withAddedHeader('Message-ID', $this->sR->getConfigAdminEmail());
-            try {
-                $this->mailer->send($email);
-            } catch (\Exception $e) {
-                $this->logger->error($e->getMessage());
-                return $this->webService->getRedirectResponse('site/signupfailed');
-            }
-        }
-        return null;
-    }
-
-    private function htmlBodyWithMaskedRandomAndTimeTokenLink(
-        User $user,
-        UIR $uiR,
-        string $language,
-        string $_language,
-        string $randomAndTimeToken,
-    ): string {
-        $tokenWithMask = TokenMask::apply($randomAndTimeToken);
-        $userInv = new UserInv();
-        $userId = $user->reqId();
-        $elcc = $this->translator->translate('email.link.click.confirm');
-        $userInv->setUserId($userId);
-        $userInv->setType($userId == 1 ? 0 : 1);
-        // Kept inactive until the confirmation link is clicked, same as the
-        // generic signup flow.
-        $userInv->setActive(false);
-        $userInv->setLanguage($language);
-        $uiR->save($userInv);
-        $content = new A()
-            ->href($this->urlGenerator->generateAbsolute(
-                'homecare/signup-confirm',
-                [
-                    '_language' => $_language,
-                    'language' => $language,
-                    'token' => $tokenWithMask,
-                    'tokenType' => 'homecare-email-verification',
-                ],
-            ))
-            ->content($elcc);
-        return new Body()
-            ->content($content)
-            ->render();
-    }
-
-    private function getEmailVerificationToken(User $user, HomeCareSignupDeps $d): string
-    {
-        $identity = $user->getIdentity();
-        $identityId = $identity->getId();
-        $token = new Token((int) $identityId, self::EMAIL_VERIFICATION_TOKEN);
-        $d->tR->save($token);
-        $tokenString = $token->getToken();
-        $timeString = (string) $token->getCreatedAt()->getTimestamp();
-        return null !== $tokenString ?
-            ($tokenString . '_' . $timeString) : '';
     }
 
     public function confirm(

--- a/src/Auth/HomeCareSignupEmailService.php
+++ b/src/Auth/HomeCareSignupEmailService.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth;
+
+use App\Auth\Controller\HomeCareSignupController;
+use App\Auth\Controller\HomeCareSignupDeps;
+use App\Auth\Form\HomeCareSignupForm;
+use App\Infrastructure\Persistence\HomeCarePendingSignup\HomeCarePendingSignup;
+use App\Infrastructure\Persistence\Token\Token;
+use App\Infrastructure\Persistence\User\User;
+use App\Infrastructure\Persistence\UserInv\UserInv;
+use App\Invoice\Setting\SettingRepository as sR;
+use App\Invoice\UserInv\UserInvRepository as UIR;
+use App\Service\WebControllerService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Log\LoggerInterface;
+use Yiisoft\Html\Tag\A;
+use Yiisoft\Html\Tag\Body;
+use Yiisoft\Mailer\Message;
+use Yiisoft\Mailer\MailerInterface;
+use Yiisoft\Router\CurrentRoute;
+use Yiisoft\Router\FastRoute\UrlGenerator;
+use Yiisoft\Security\TokenMask;
+use Yiisoft\Translator\TranslatorInterface as Translator;
+
+/**
+ * Pending-signup persistence and verification-email dispatch for the HomeCare public signup flow — split
+ * out of HomeCareSignupController purely to keep that class under SonarQube's php:S1448 method-count
+ * ceiling (20 methods), the same reasoning already documented for ClientDwellingRepository/
+ * ProductNameTypeRepository splitting out of their respective repositories.
+ */
+final readonly class HomeCareSignupEmailService
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private sR $sR,
+        private Translator $translator,
+        private UrlGenerator $urlGenerator,
+        private LoggerInterface $logger,
+        private WebControllerService $webService,
+    ) {
+    }
+
+    public function savePendingSignup(int $userId, HomeCareSignupForm $signupForm, HomeCareSignupDeps $d): void
+    {
+        $pending = new HomeCarePendingSignup();
+        $pending->setUserId($userId);
+        $pending->setClientName($signupForm->getClientName());
+        $pending->setClientSurname($signupForm->getClientSurname());
+        $pending->setStreet($signupForm->getStreet());
+        $pending->setBuildingNumber($signupForm->getBuildingNumber());
+        $pending->setPrice((float) $signupForm->getPrice());
+        $pending->setPaymentOption($signupForm->getPaymentOption());
+        $pending->setSecondaryCategoryId($signupForm->getSecondaryCategoryId());
+        $d->pendingR->save($pending);
+    }
+
+    public function processSendSignupEmail(
+        User $user,
+        CurrentRoute $currentRoute,
+        HomeCareSignupDeps $d,
+    ): ?Response {
+        $to = $user->getEmail();
+        $login = $user->getLogin();
+        $languageArray = $this->sR->localeLanguageArray();
+        $_language = $currentRoute->getArgument('_language');
+        /**
+         * @var string $_language
+         * @var string $language
+         */
+        $language = $languageArray[$_language];
+        $randomAndTimeToken = $this->getEmailVerificationToken($user, $d);
+        $htmlBody = $this->htmlBodyWithMaskedRandomAndTimeTokenLink(
+            $user, $d->uiR, $language, $_language, $randomAndTimeToken);
+        if (($this->sR->getSetting('email_send_method') == 'symfony')
+                || ($this->sR->mailerEnabled())) {
+            $configEmail = $this->sR->getConfigAdminEmail();
+            $tta = $this->translator->translate('administrator');
+            $email = new Message(
+                charset: 'utf-8',
+                headers: [
+                    'X-Origin' => ['0', '1'],
+                    'X-Pass' => 'pass',
+                ],
+                subject: $login . ': <' . $to . '>',
+                date: new \DateTimeImmutable('now'),
+                from: [$configEmail => $tta],
+                to: $to,
+                htmlBody: $htmlBody,
+            );
+            $email->withAddedHeader('Message-ID', $this->sR->getConfigAdminEmail());
+            try {
+                $this->mailer->send($email);
+            } catch (\Exception $e) {
+                $this->logger->error($e->getMessage());
+                return $this->webService->getRedirectResponse('site/signupfailed');
+            }
+        }
+        return null;
+    }
+
+    private function htmlBodyWithMaskedRandomAndTimeTokenLink(
+        User $user,
+        UIR $uiR,
+        string $language,
+        string $_language,
+        string $randomAndTimeToken,
+    ): string {
+        $tokenWithMask = TokenMask::apply($randomAndTimeToken);
+        $userInv = new UserInv();
+        $userId = $user->reqId();
+        $elcc = $this->translator->translate('email.link.click.confirm');
+        $userInv->setUserId($userId);
+        $userInv->setType($userId == 1 ? 0 : 1);
+        // Kept inactive until the confirmation link is clicked, same as the
+        // generic signup flow.
+        $userInv->setActive(false);
+        $userInv->setLanguage($language);
+        $uiR->save($userInv);
+        $content = new A()
+            ->href($this->urlGenerator->generateAbsolute(
+                'homecare/signup-confirm',
+                [
+                    '_language' => $_language,
+                    'language' => $language,
+                    'token' => $tokenWithMask,
+                    'tokenType' => 'homecare-email-verification',
+                ],
+            ))
+            ->content($elcc);
+        return new Body()
+            ->content($content)
+            ->render();
+    }
+
+    private function getEmailVerificationToken(User $user, HomeCareSignupDeps $d): string
+    {
+        $identity = $user->getIdentity();
+        $identityId = $identity->getId();
+        $token = new Token((int) $identityId, HomeCareSignupController::EMAIL_VERIFICATION_TOKEN);
+        $d->tR->save($token);
+        $tokenString = $token->getToken();
+        $timeString = (string) $token->getCreatedAt()->getTimestamp();
+        return null !== $tokenString ?
+            ($tokenString . '_' . $timeString) : '';
+    }
+}

--- a/src/Invoice/Client/ClientDwellingRepository.php
+++ b/src/Invoice/Client/ClientDwellingRepository.php
@@ -21,14 +21,6 @@ use Cycle\ORM\Select;
 final class ClientDwellingRepository extends Select\Repository
 {
     /**
-     * @param Select<TEntity> $select
-     */
-    public function __construct(Select $select)
-    {
-        parent::__construct($select);
-    }
-
-    /**
      * Every dwelling_id currently claimed by a Client — the "already occupied" side of the worker
      * canvassing dropdown's unclaimed-Dwelling anti-join, composed at the service layer
      * ({@see \App\Invoice\Dwelling\DwellingService::repoUnclaimedDwellings()}).

--- a/src/Invoice/Product/ProductNameTypeRepository.php
+++ b/src/Invoice/Product/ProductNameTypeRepository.php
@@ -21,14 +21,6 @@ use Cycle\ORM\Select;
 final class ProductNameTypeRepository extends Select\Repository
 {
     /**
-     * @param Select<TEntity> $select
-     */
-    public function __construct(Select $select)
-    {
-        parent::__construct($select);
-    }
-
-    /**
      * Exact match on product_name + product_type, unscoped by family — used to find-or-create the single
      * shared Service-type Product a HomeCare invoice line references (see
      * {@see \App\Invoice\Product\ProductService::findOrCreateHomeCareServiceProduct()}), where family_id

--- a/src/Invoice/Setting/Console/CheckGatewaySecretsCommand.php
+++ b/src/Invoice/Setting/Console/CheckGatewaySecretsCommand.php
@@ -86,7 +86,9 @@ final class CheckGatewaySecretsCommand extends Command
     /**
      * Checks a single driver/field's stored secret, writing its result line to $io whenever it was
      * actually a configured password secret. Split out of execute() purely to keep its cognitive
-     * complexity within SonarQube's limit (php:S3776).
+     * complexity within SonarQube's limit (php:S3776); the decode/report step is further split into
+     * decodeAndReportSecret() purely to keep this method's own return count within SonarQube's limit
+     * (php:S1142).
      *
      * @param array{type: string, label: string} $setting
      *
@@ -102,8 +104,14 @@ final class CheckGatewaySecretsCommand extends Command
         if ($stored === '') {
             return null; // never configured — not this regression's concern
         }
+        return $this->decodeAndReportSecret("{$driver}.{$key}", $stored, $io);
+    }
 
-        $label = "{$driver}.{$key}";
+    /**
+     * @return string '' when the secret decodes cleanly; the corrupted $label otherwise.
+     */
+    private function decodeAndReportSecret(string $label, string $stored, SymfonyStyle $io): string
+    {
         try {
             $decoded = (string) $this->sR->decode($stored);
             if ($decoded === '' || !mb_check_encoding($decoded, 'UTF-8')) {


### PR DESCRIPTION
Follow-up to #1058 — the fixes there introduced these 4 new findings, now addressed.

| Rule | File | Fix |
|---|---|---|
| php:S1185 x2 | `ClientDwellingRepository.php:26`, `ProductNameTypeRepository.php:26` | Both had a `__construct()` that did nothing but call `parent::__construct()` with the identical signature — `Cycle\ORM\Select\Repository`'s own constructor already does this. Removed both redundant overrides; the DI factories in `config/common/di/cycle.php` are unaffected since the inherited signature is identical |
| php:S1142 (5 returns > 3) | `CheckGatewaySecretsCommand.php:96` | `checkGatewaySecret()` grew to 5 returns after the last PR's S3776 fix. Split the decode/report branch into `decodeAndReportSecret()`, leaving `checkGatewaySecret()` with its original 3 |
| php:S1448 (21 methods > 20) | `HomeCareSignupController.php:62` | Grew to 21 methods after the last PR's S1142 fix. Extracted the pending-signup persistence + verification-email dispatch (`savePendingSignup`, `processSendSignupEmail`, `htmlBodyWithMaskedRandomAndTimeTokenLink`, `getEmailVerificationToken` — all only reachable from `signup()`) into a new `HomeCareSignupEmailService`, following the same reasoning as the repository splits in #1058. `MailerInterface`/`LoggerInterface` moved out of the controller's constructor with them, since nothing else there used them. Controller now at 17 methods |

## Verification
- `php -l` on every changed/new file
- Full-project `vendor/bin/psalm --no-cache` — no errors
- Full PHPUnit suite — 3896 tests, 0 failures
- Full Testo suite — 828 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)