### PR TITLE
Fix 4 SonarQube findings surfaced by the test-classification fix

### DIFF
--- a/src/typescript/allowance-charge-toggle.test.ts
+++ b/src/typescript/allowance-charge-toggle.test.ts
@@ -83,10 +83,26 @@ describe('AllowanceChargeToggleHandler — initial applyMode', () => {
     });
     afterEach(() => { document.body.innerHTML = ''; });
 
-    it('hides baseRow on init when the selected template has mfn = 0', () => {
-        const { baseRow } = makeDOM('1');
+    it.each([
+        {
+            description: 'hides baseRow on init when the selected template has mfn = 0',
+            selectValue: '1',
+            expectedDisplay: 'none',
+        },
+        {
+            description: 'shows baseRow on init when the selected template has mfn > 0',
+            selectValue: '2',
+            expectedDisplay: '',
+        },
+        {
+            description: 'hides baseRow for an unknown select value (falls back to mfn=0)',
+            selectValue: '99', // value not in TEMPLATES → getTemplate returns { mfn:0, base:0 }
+            expectedDisplay: 'none',
+        },
+    ])('$description', ({ selectValue, expectedDisplay }) => {
+        const { baseRow } = makeDOM(selectValue);
         const _handler = new AllowanceChargeToggleHandler();
-        expect(baseRow.style.display).toBe('none');
+        expect(baseRow.style.display).toBe(expectedDisplay);
     });
 
     it('clears formulaHint on init when mfn = 0', () => {
@@ -94,12 +110,6 @@ describe('AllowanceChargeToggleHandler — initial applyMode', () => {
         formulaHint.textContent = 'leftover text';
         const _handler = new AllowanceChargeToggleHandler();
         expect(formulaHint.textContent).toBe('');
-    });
-
-    it('shows baseRow on init when the selected template has mfn > 0', () => {
-        const { baseRow } = makeDOM('2');
-        const _handler = new AllowanceChargeToggleHandler();
-        expect(baseRow.style.display).toBe('');
     });
 
     it('pre-fills baseInput with template.base on init', () => {
@@ -120,13 +130,6 @@ describe('AllowanceChargeToggleHandler — initial applyMode', () => {
         const { formulaHint } = makeDOM('2');
         const _handler = new AllowanceChargeToggleHandler();
         expect(formulaHint.textContent).toBe('10 × 500 ÷ 100 = 50.00');
-    });
-
-    it('hides baseRow for an unknown select value (falls back to mfn=0)', () => {
-        // value='99' not in TEMPLATES → getTemplate returns { mfn:0, base:0 }
-        const { baseRow } = makeDOM('99');
-        const _handler = new AllowanceChargeToggleHandler();
-        expect(baseRow.style.display).toBe('none');
     });
 });
 

--- a/src/typescript/cron.test.ts
+++ b/src/typescript/cron.test.ts
@@ -116,12 +116,16 @@ describe('initGenerateCronKey', () => {
         vi.unstubAllGlobals();
     });
 
-    it('does not throw when clipboard is unavailable', async () => {
+    it('still fills the input and falls back to the repeat icon when clipboard is unavailable', async () => {
         vi.stubGlobal('navigator', { clipboard: undefined });
-        const { btn } = makeDOM();
+        const { btn, input } = makeDOM();
         initGenerateCronKey();
         btn.click();
         await vi.runAllTimersAsync();
+        // Clipboard copy is best-effort — the key still lands in the field either way,
+        // and the button shows the repeat icon (not the clipboard success checkmark).
+        expect(input.value).toBe('ab'.repeat(24));
+        expect(btn.innerHTML).toContain('bi-arrow-repeat');
         vi.unstubAllGlobals();
     });
 

--- a/src/typescript/inv-index.test.ts
+++ b/src/typescript/inv-index.test.ts
@@ -58,7 +58,7 @@ describe('initInvIndex', () => {
         initInvIndex();
         document.body.innerHTML = '';
         initInvIndex();
-        expect(document.querySelectorAll('#mp-styles').length).toBe(1);
+        expect(document.querySelectorAll('#mp-styles')).toHaveLength(1);
     });
 
     it('creates toggle button with label span and dismiss button', () => {

--- a/src/typescript/phone-e164.test.ts
+++ b/src/typescript/phone-e164.test.ts
@@ -7,24 +7,32 @@ describe('initE164PhoneFields', () => {
         initE164PhoneFields();
     });
 
-    it('reformats a UK national number to E.164 on blur, using the default region', () => {
-        document.body.innerHTML =
-            '<input id="client_mobile" data-e164 data-e164-default-region="GB" value="07726232648">';
-        const input = document.getElementById('client_mobile') as HTMLInputElement;
+    it.each([
+        {
+            description: 'reformats a UK national number to E.164 on blur, using the default region',
+            html: '<input id="client_mobile" data-e164 data-e164-default-region="GB" value="07726232648">',
+            id: 'client_mobile',
+            expectedValue: '+447726232648',
+        },
+        {
+            description: 'accepts an already-international number with no default region set',
+            html: '<input id="phone" data-e164 data-e164-default-region="" value="+447726232648">',
+            id: 'phone',
+            expectedValue: '+447726232648',
+        },
+        {
+            description: 'does not touch inputs without data-e164',
+            html: '<input id="client_web" value="not-a-phone-number">',
+            id: 'client_web',
+            expectedValue: 'not-a-phone-number',
+        },
+    ])('$description', ({ html, id, expectedValue }) => {
+        document.body.innerHTML = html;
+        const input = document.getElementById(id) as HTMLInputElement;
 
         input.dispatchEvent(new FocusEvent('blur'));
 
-        expect(input.value).toBe('+447726232648');
-        expect(input.classList.contains('is-invalid')).toBe(false);
-    });
-
-    it('accepts an already-international number with no default region set', () => {
-        document.body.innerHTML = '<input id="phone" data-e164 data-e164-default-region="" value="+447726232648">';
-        const input = document.getElementById('phone') as HTMLInputElement;
-
-        input.dispatchEvent(new FocusEvent('blur'));
-
-        expect(input.value).toBe('+447726232648');
+        expect(input.value).toBe(expectedValue);
         expect(input.classList.contains('is-invalid')).toBe(false);
     });
 
@@ -50,15 +58,5 @@ describe('initE164PhoneFields', () => {
 
         expect(input.classList.contains('is-invalid')).toBe(false);
         expect(document.getElementById('client_mobile-e164-feedback')).toBeNull();
-    });
-
-    it('does not touch inputs without data-e164', () => {
-        document.body.innerHTML = '<input id="client_web" value="not-a-phone-number">';
-        const input = document.getElementById('client_web') as HTMLInputElement;
-
-        input.dispatchEvent(new FocusEvent('blur'));
-
-        expect(input.value).toBe('not-a-phone-number');
-        expect(input.classList.contains('is-invalid')).toBe(false);
     });
 });


### PR DESCRIPTION
Follow-up to #1068's `sonar-project.properties` fix (correctly declaring `*.test.ts` as test code). These pre-existing test files now get test-specific SonarQube rules applied for the first time, surfacing 4 real findings:

- **BLOCKER `typescript:S2699`** — `cron.test.ts:119`, a test with no assertion at all. Added real assertions matching the test's stated intent (clipboard-unavailable fallback): the key still lands in the input, and the button shows the repeat icon instead of the clipboard success checkmark.
- **`typescript:S5976` (x2)** — 3 structurally identical tests each in `phone-e164.test.ts` and `allowance-charge-toggle.test.ts` consolidated into a single `it.each`. No coverage lost — same number of individual test executions before/after.
- **`typescript:S5906`** — `inv-index.test.ts:61`, same `.length).toBe(1)` → `toHaveLength(1)` pattern already fixed elsewhere in #1068; swept the rest of `src/typescript/*.test.ts` for the same pattern, none left.

Verified: `npx tsc --noEmit` clean, vitest 176/176 passed (same total individual test executions as before).
