### PR TITLE
security: remove real phone number from test fixtures

### DIFF
--- a/Tests/Unit/Invoice/Form/ClientFormTest.php
+++ b/Tests/Unit/Invoice/Form/ClientFormTest.php
@@ -142,7 +142,7 @@ class ClientFormTest extends TestCase
     public function testClientMobileAcceptsE164Format(): void
     {
         $form = $this->validFormForValidation();
-        $form->client_mobile = '+447726232648';
+        $form->client_mobile = '+447000000000';
 
         $result = new Validator()->validate($form);
 
@@ -152,7 +152,7 @@ class ClientFormTest extends TestCase
     public function testClientMobileRejectsNationalFormat(): void
     {
         $form = $this->validFormForValidation();
-        $form->client_mobile = '07726232648';
+        $form->client_mobile = '07000000000';
 
         $result = new Validator()->validate($form);
 
@@ -162,7 +162,7 @@ class ClientFormTest extends TestCase
     public function testClientMobileRejectsLeadingZeroAfterPlus(): void
     {
         $form = $this->validFormForValidation();
-        $form->client_mobile = '+0447726232648';
+        $form->client_mobile = '+0447000000000';
 
         $result = new Validator()->validate($form);
 

--- a/Tests/Unit/Invoice/Form/CompanyFormTest.php
+++ b/Tests/Unit/Invoice/Form/CompanyFormTest.php
@@ -110,7 +110,7 @@ class CompanyFormTest extends TestCase
     public function testPhoneAcceptsE164Format(): void
     {
         $form = $this->validFormForValidation();
-        $form->phone = '+447726232648';
+        $form->phone = '+447000000000';
 
         $result = new Validator()->validate($form);
 
@@ -120,7 +120,7 @@ class CompanyFormTest extends TestCase
     public function testPhoneRejectsNationalFormat(): void
     {
         $form = $this->validFormForValidation();
-        $form->phone = '07726232648';
+        $form->phone = '07000000000';
 
         $result = new Validator()->validate($form);
 

--- a/src/typescript/phone-e164.test.ts
+++ b/src/typescript/phone-e164.test.ts
@@ -10,15 +10,15 @@ describe('initE164PhoneFields', () => {
     it.each([
         {
             description: 'reformats a UK national number to E.164 on blur, using the default region',
-            html: '<input id="client_mobile" data-e164 data-e164-default-region="GB" value="07726232648">',
+            html: '<input id="client_mobile" data-e164 data-e164-default-region="GB" value="07000000000">',
             id: 'client_mobile',
-            expectedValue: '+447726232648',
+            expectedValue: '+447000000000',
         },
         {
             description: 'accepts an already-international number with no default region set',
-            html: '<input id="phone" data-e164 data-e164-default-region="" value="+447726232648">',
+            html: '<input id="phone" data-e164 data-e164-default-region="" value="+447000000000">',
             id: 'phone',
-            expectedValue: '+447726232648',
+            expectedValue: '+447000000000',
         },
         {
             description: 'does not touch inputs without data-e164',


### PR DESCRIPTION
A real phone number has been used as test fixture data since it was first introduced (983a4c23) and carried forward unchanged through every subsequent refactor of these 3 files. Replaced with `07000000000`/`+447000000000` — confirmed valid per `libphonenumber-js` (the actual validator these tests exercise) while being about as clearly non-personal as a UK mobile number can be.

**This fixes the file going forward only — it does not remove the number from git history.** Flagged to the user separately for a decision on whether to rewrite history.

Affected: `src/typescript/phone-e164.test.ts`, `Tests/Unit/Invoice/Form/ClientFormTest.php`, `Tests/Unit/Invoice/Form/CompanyFormTest.php`.

Verified: full-tree grep clean, `npx tsc --noEmit` clean, vitest 176/176, full PHPUnit 3907/3907.