### PR TITLE
ci: add PHP 8.6 and 9.0 as experimental matrix legs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,11 +31,22 @@ jobs:
   benchmark:
     name: Yii3-i Benchmarks · PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.4']   # extend to ['8.4','8.5'] when 8.5 is stable
+        # extend to ['8.4','8.5'] when 8.5 is stable. PHP 8.6/9.0 are
+        # pre-release — tolerated via continue-on-error rather than
+        # blocking the primary 8.4 leg (which also owns the "Commit
+        # results" step below).
+        include:
+          - php: '8.4'
+            experimental: false
+          - php: '8.6'
+            experimental: true
+          - php: '9.0'
+            experimental: true
 
     steps:
       # ── Checkout ────────────────────────────────────────────────────────────

--- a/.github/workflows/invoice_build.yml
+++ b/.github/workflows/invoice_build.yml
@@ -89,16 +89,40 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 6
-    
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
+    continue-on-error: ${{ matrix.experimental }}
 
-        php:
-          - 8.4  
-          - 8.5
+    strategy:
+      fail-fast: false
+      matrix:
+        # PHP 8.6/9.0 are pre-release — tolerated via continue-on-error rather
+        # than blocking the required 8.4/8.5 legs. windows-latest is paired
+        # explicitly with every PHP version rather than a free os x php
+        # cross-product, so each experimental leg carries its own flag.
+        include:
+          - os: ubuntu-latest
+            php: '8.4'
+            experimental: false
+          - os: ubuntu-latest
+            php: '8.5'
+            experimental: false
+          - os: ubuntu-latest
+            php: '8.6'
+            experimental: true
+          - os: ubuntu-latest
+            php: '9.0'
+            experimental: true
+          - os: windows-latest
+            php: '8.4'
+            experimental: false
+          - os: windows-latest
+            php: '8.5'
+            experimental: false
+          - os: windows-latest
+            php: '8.6'
+            experimental: true
+          - os: windows-latest
+            php: '9.0'
+            experimental: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/invoice_dependency.yml
+++ b/.github/workflows/invoice_dependency.yml
@@ -32,14 +32,23 @@ jobs:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
         
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
+      fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-
-        php:
-          - 8.4
+        # PHP 8.6/9.0 are pre-release — tolerated via continue-on-error
+        # rather than blocking the required 8.4 leg.
+        include:
+          - os: ubuntu-latest
+            php: '8.4'
+            experimental: false
+          - os: ubuntu-latest
+            php: '8.6'
+            experimental: true
+          - os: ubuntu-latest
+            php: '9.0'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/invoice_static.yml
+++ b/.github/workflows/invoice_static.yml
@@ -33,14 +33,23 @@ jobs:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
+      fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-
-        php:
-          - 8.5
+        # PHP 8.6/9.0 are pre-release — tolerated via continue-on-error
+        # rather than blocking the required 8.5 leg.
+        include:
+          - os: ubuntu-latest
+            php: '8.5'
+            experimental: false
+          - os: ubuntu-latest
+            php: '8.6'
+            experimental: true
+          - os: ubuntu-latest
+            php: '9.0'
+            experimental: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/php-cve-check.yml
+++ b/.github/workflows/php-cve-check.yml
@@ -10,13 +10,22 @@ jobs:
   security-audit:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/typescript'
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     concurrency:
-      group: php-cve-check-${{ github.ref }}
+      group: php-cve-check-${{ github.ref }}-${{ matrix.php }}
       cancel-in-progress: true
     strategy:
+      fail-fast: false
       matrix:
-        php:
-          - '8.4'
+        # PHP 8.6/9.0 are pre-release — tolerated via continue-on-error
+        # rather than blocking the required 8.4 leg.
+        include:
+          - php: '8.4'
+            experimental: false
+          - php: '8.6'
+            experimental: true
+          - php: '9.0'
+            experimental: true
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "8.4 - 8.5",
+        "php": "8.4 - 9.0",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-curl": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "047537ad402ef76531178cb93aeeb595",
+    "content-hash": "51cca97eccc91ea34d76eacf57226458",
     "packages": [
         {
             "name": "adyen/php-api-library",
@@ -27535,7 +27535,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "8.4 - 8.5",
+        "php": "8.4 - 9.0",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-curl": "*",


### PR DESCRIPTION
Adds PHP 8.6 and 9.0 as experimental legs (`continue-on-error: ${{ matrix.experimental }}`, `fail-fast: false`) to every workflow with a real PHP-version matrix: `invoice_build.yml` (tests), `invoice_dependency.yml` (mutation), `invoice_static.yml` (psalm), `benchmark.yml`, `php-cve-check.yml`.

Also widens `composer.json`'s `php` constraint from `8.4 - 8.5` to `8.4 - 9.0` — without this every experimental leg would fail at Composer's platform check before running any real code. `composer.lock`'s content-hash re-synced (metadata only, 0 installs/updates/removals).

**Findings worth knowing:**
- PHP 8.6 is real and meaningful — `shivammathur/setup-php` installs a nightly build from PHP's actual master branch when you specify it.
- PHP 9.0 doesn't correspond to any real PHP branch yet and isn't in `setup-php`'s documented support range (5.3–8.6) — those legs will most likely fail cleanly at the "Install PHP" step every run. Kept as requested since it's harmless (experimental + continue-on-error) and will start providing real signal once PHP 9.0 actually exists.
- Also fixed a latent bug in `php-cve-check.yml`: its concurrency group didn't include `matrix.php`, so once the matrix grew past one leg they'd all share one group and `cancel-in-progress` would cancel each other.

**Deliberately not touched** (with reasons in the commit message): the 3 Alpine-container jobs (no apk packages for 8.6/9.0 yet), `cs.yml` (single-PHP auto-fix bot), `gateway-status.yml` (hits real external APIs), `codeql.yml`/`eslint.yml` (no PHP matrix at all).

Verified: all 9 workflow YAML files re-validated, `composer validate` clean, full PHPUnit Unit suite 3854/3854 passing.