### PR TITLE
fix(settings): Checkout.com label overrides never actually rendered

### DIFF
--- a/resources/messages/en/app.php
+++ b/resources/messages/en/app.php
@@ -1600,6 +1600,14 @@ prior to importing and no existing documents e.g. Invoices.',
   'online.payment.webhookId' => 'Webhook Id',
   'online.payment.webhookSecret' => 'Webhook Secret',
   'online.payment.websiteKey' => 'Website Key',
+  // Per-gateway overrides — partial_settings_online_payment.php tries
+  // 'online.payment.{driver}.{key}' before falling back to the generic
+  // 'online.payment.{key}' above. Only add one here when a gateway's own
+  // dashboard genuinely uses different wording than the generic label —
+  // most gateways should keep sharing the generic key as-is.
+  'online.payment.checkout_com.secretKey' => 'Secret API Key',
+  'online.payment.checkout_com.publicKey' => 'Public API Key',
+  'online.payment.checkout_com.webhookSecret' => 'Webhook Signature Key',
   'online.payments' => 'Online Payments',
   'open.banking.pay.with' => 'Pay with Open Banking: ',
   'open.banking.not.configured' =>

--- a/resources/views/invoice/setting/views/partial_settings_online_payment.php
+++ b/resources/views/invoice/setting/views/partial_settings_online_payment.php
@@ -289,9 +289,19 @@ echo H::openTag('div', $row); //1
      'for' => $pfxGateway . $d . '_' .
      $key . ']'
     ]);
-      echo $translator->translate(
-       'online.payment.' . $key
-      );
+      // Most gateways share the generic online.payment.{key} label
+      // ('Secret Key', 'Webhook Secret', ...) — fine when every gateway
+      // really does call it that. Where a gateway's own dashboard uses
+      // different wording (e.g. Checkout.com's 'Secret API Key'/'Webhook
+      // Signature Key'), an online.payment.{driver}.{key} override takes
+      // priority. translate() returns the id itself, unchanged, when no
+      // message is defined for it — the documented Yii3 way to detect a
+      // missing key, used here rather than a separate "has key" lookup.
+      $gatewaySpecificLabelKey = 'online.payment.' . $d . '.' . $key;
+      $gatewaySpecificLabel = $translator->translate($gatewaySpecificLabelKey);
+      echo $gatewaySpecificLabel !== $gatewaySpecificLabelKey
+       ? $gatewaySpecificLabel
+       : $translator->translate('online.payment.' . $key);
      echo H::closeTag('label');
      echo H::openTag('input', [
       'type' => $setting['type'],


### PR DESCRIPTION
Root cause of PR #1076's label fix not showing up on localhost or yii3i.online: `partial_settings_online_payment.php`'s password/text-type field labels never read `SettingPaymentTrait`'s per-gateway `'label'` value at all — they render `$translator->translate('online.payment.' . $key)`, a label shared across every gateway with a field of that name. Matches this project's own standing note that `partial_settings_online_payment.php` ignores non-checkbox field labels.

Diagnosed by ruling out every caching layer first — merged file content, opcache config (`validate_timestamps=1`, `revalidate_freq=0`), a full Apache restart, and a direct reflection call against the real running web server all confirmed correct — before finding the view genuinely never touched PR #1076's edit.

**Fix**: the view now tries `online.payment.{driver}.{key}` first, falling back to the existing generic `online.payment.{key}` — using `translate()`'s documented behavior of returning the id itself when no message exists, rather than a separate has-key lookup. Added the 3 Checkout.com-specific overrides to `app.php` only. Every other gateway is untouched — confirmed live via Playwright (Adyen's 'Secret Key' unchanged, Checkout.com now reads 'Secret API Key'/'Webhook Signature Key').

Verified: `php -l` clean, full-project Psalm clean, PHPUnit Unit 3854/3854, Testo Unit 828/828, confirmed live end-to-end against the real running page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Gateway-specific labels are now displayed for Checkout.com secret key, public key, and webhook secret fields.
  * Payment settings automatically use gateway-specific translations when available, with a fallback to generic labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->