### PR TITLE
fix(rate-limiter): redirect to login instead of a bare unstyled 429

### DIFF
--- a/Tests/Testo/Middleware/RateLimitRedirectMiddlewareTest.php
+++ b/Tests/Testo/Middleware/RateLimitRedirectMiddlewareTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Middleware;
+
+use App\Middleware\RateLimitRedirectMiddleware;
+use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Testo\Assert;
+use Testo\Test;
+use Yiisoft\Http\Header;
+use Yiisoft\Http\Status;
+
+/**
+ * @see RateLimitRedirectMiddleware
+ */
+#[Test]
+final class RateLimitRedirectMiddlewareTest
+{
+    /** Always returns $statusCode — used to stand in for the wrapped limiter. */
+    private function makeInner(int $statusCode): MiddlewareInterface
+    {
+        return new class ($statusCode) implements MiddlewareInterface {
+            public function __construct(private readonly int $statusCode)
+            {
+            }
+
+            #[\Override]
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler,
+            ): ResponseInterface {
+                return new HttpFactory()->createResponse($this->statusCode);
+            }
+        };
+    }
+
+    /** Throws if called — proves the caller reached the real handler, not the inner limiter's stub. */
+    private function makeThrowingHandler(): RequestHandlerInterface
+    {
+        return new class implements RequestHandlerInterface {
+            #[\Override]
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                throw new \LogicException('handler should not be called in this test');
+            }
+        };
+    }
+
+    /** Returns a fixed 200 with a recognisable body, to prove it — not the inner limiter — ran. */
+    private function makeOkHandler(): RequestHandlerInterface
+    {
+        return new class implements RequestHandlerInterface {
+            #[\Override]
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $response = new HttpFactory()->createResponse(Status::OK);
+                $response->getBody()->write('handled-directly');
+                return $response;
+            }
+        };
+    }
+
+    public function redirectsToTheSameUriWhenAPostRequestHitsTheLimit(): void
+    {
+        $factory = new HttpFactory();
+        $middleware = new RateLimitRedirectMiddleware($this->makeInner(Status::TOO_MANY_REQUESTS), $factory);
+        $request = $factory->createServerRequest('POST', 'https://example.test/en/login');
+
+        $result = $middleware->process($request, $this->makeThrowingHandler());
+
+        Assert::same($result->getStatusCode(), Status::FOUND);
+        Assert::same($result->getHeaderLine(Header::LOCATION), 'https://example.test/en/login');
+    }
+
+    public function passesThroughUnchangedWhenAPostRequestDoesNotHitTheLimit(): void
+    {
+        $factory = new HttpFactory();
+        $middleware = new RateLimitRedirectMiddleware($this->makeInner(Status::OK), $factory);
+        $request = $factory->createServerRequest('POST', 'https://example.test/en/login');
+
+        $result = $middleware->process($request, $this->makeThrowingHandler());
+
+        Assert::same($result->getStatusCode(), Status::OK);
+        Assert::same($result->getHeaderLine(Header::LOCATION), '');
+    }
+
+    public function passesThroughOtherErrorStatusesUnchangedOnPost(): void
+    {
+        // Only 429 is special-cased — anything else (a 500 from downstream,
+        // say) must not be silently swallowed into a redirect.
+        $factory = new HttpFactory();
+        $middleware = new RateLimitRedirectMiddleware(
+            $this->makeInner(Status::INTERNAL_SERVER_ERROR),
+            $factory,
+        );
+        $request = $factory->createServerRequest('POST', 'https://example.test/en/login');
+
+        $result = $middleware->process($request, $this->makeThrowingHandler());
+
+        Assert::same($result->getStatusCode(), Status::INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * The regression this test guards against was found live, not in a
+     * unit test: a real browser hit ERR_TOO_MANY_REDIRECTS because a GET
+     * page view was itself being counted against the same limiter as the
+     * POST submissions, and a GET that trips the limit was redirecting
+     * back to that exact same (still over-budget) GET, looping forever
+     * for the rest of the window. GET must never reach the inner limiter
+     * at all — the inner stub here returns 429 unconditionally, so this
+     * test would fail immediately (a 302-to-self loop, exactly like the
+     * live bug) if that guard regressed.
+     */
+    public function neverConsultsTheInnerLimiterForASafeMethod(): void
+    {
+        $factory = new HttpFactory();
+        $middleware = new RateLimitRedirectMiddleware($this->makeInner(Status::TOO_MANY_REQUESTS), $factory);
+        $request = $factory->createServerRequest('GET', 'https://example.test/en/login');
+
+        $result = $middleware->process($request, $this->makeOkHandler());
+
+        Assert::same($result->getStatusCode(), Status::OK);
+        Assert::same((string) $result->getBody(), 'handled-directly');
+    }
+
+    public function neverConsultsTheInnerLimiterForHeadOrOptions(): void
+    {
+        $factory = new HttpFactory();
+
+        foreach (['HEAD', 'OPTIONS'] as $method) {
+            $middleware = new RateLimitRedirectMiddleware($this->makeInner(Status::TOO_MANY_REQUESTS), $factory);
+            $request = $factory->createServerRequest($method, 'https://example.test/en/login');
+
+            $result = $middleware->process($request, $this->makeOkHandler());
+
+            Assert::same($result->getStatusCode(), Status::OK);
+        }
+    }
+}

--- a/src/Middleware/RateLimitRedirectMiddleware.php
+++ b/src/Middleware/RateLimitRedirectMiddleware.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Http\Header;
+use Yiisoft\Http\Method;
+use Yiisoft\Http\Status;
+
+/**
+ * Wraps a rate-limiting middleware (LimitRequestsMiddleware, or
+ * TooManyRequestsMiddleware's own CAS-failure path — both return a bare
+ * 429 with no Content-Type set, rendered by every browser as unstyled
+ * black-on-white text) and turns a 429 into a plain redirect back to the
+ * page the request was for instead.
+ *
+ * Mirrors AuthController::login()'s own controller-level rate-limit check
+ * (AuthSecurityHelper::checkRateLimit()/checkAccountRateLimit()), which
+ * already does exactly this — redirect back, no error message — for its
+ * own, separate rate-limit layer. This applies the same behaviour to the
+ * outer PSR-15 middleware layer (RateLimiter::global()/perIp()), which
+ * runs before any controller and so has no form/session context to build
+ * a proper validation-style error message the way the controller-level
+ * check can.
+ *
+ * Redirects to the exact request URI rather than a named route, so this
+ * works unmodified for every route it wraps (login, forgotpassword,
+ * resetpassword, signup, ...) without per-route configuration. A 302 to
+ * a POST is followed as a GET by every browser, so this is a normal
+ * Post/Redirect/Get bounce back to the same form, not a resubmission.
+ *
+ * Safe/idempotent methods (GET, HEAD, OPTIONS) never reach the inner
+ * limiter at all — confirmed live that leaving them counted (as the
+ * wrapped LimitRequestsMiddleware does by default, sharing one counter
+ * across every method Route::methods() registers) is actively dangerous
+ * once 429s redirect: a plain page view that itself trips the limit would
+ * redirect back to that exact same GET, which is still over budget for
+ * the rest of the window, producing an infinite redirect loop
+ * (ERR_TOO_MANY_REDIRECTS) rather than the intended one-time bounce.
+ * Mirrors AuthController::login()'s own controller-level rate-limit
+ * check, which already only ever throttles POST for the same reason.
+ */
+final class RateLimitRedirectMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly MiddlewareInterface $inner,
+        private readonly ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    #[\Override]
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        if (in_array($request->getMethod(), [Method::GET, Method::HEAD, Method::OPTIONS], true)) {
+            return $handler->handle($request);
+        }
+
+        $response = $this->inner->process($request, $handler);
+
+        if ($response->getStatusCode() !== Status::TOO_MANY_REQUESTS) {
+            return $response;
+        }
+
+        return $this->responseFactory
+            ->createResponse(Status::FOUND)
+            ->withHeader(Header::LOCATION, (string) $request->getUri());
+    }
+}

--- a/src/Middleware/RateLimiter.php
+++ b/src/Middleware/RateLimiter.php
@@ -17,6 +17,12 @@ use Yiisoft\Yii\RateLimiter\Storage\StorageInterface;
  * Shared rate-limiter builders for config/common/routes/routes.php, avoiding
  * the repeated global/per-IP limiter closures duplicated across the auth
  * routes (login, forgotpassword, resetpassword, signup, change).
+ *
+ * Both builders wrap LimitRequestsMiddleware in RateLimitRedirectMiddleware,
+ * so a request that actually trips the limit gets redirected back to the
+ * page it was for instead of the bare, unstyled 429 LimitRequestsMiddleware
+ * (and TooManyRequestsMiddleware, for the CAS-failure case) return on their
+ * own — see RateLimitRedirectMiddleware's own docblock.
  */
 final class RateLimiter
 {
@@ -25,11 +31,14 @@ final class RateLimiter
      */
     public static function global(int $limit, int $window = 60): Closure
     {
-        return static fn (ResponseFactoryInterface $responseFactory, StorageInterface $storage) => new LimitRequestsMiddleware(
-            new Counter($storage, $limit, $window),
+        return static fn (ResponseFactoryInterface $responseFactory, StorageInterface $storage) => new RateLimitRedirectMiddleware(
+            new LimitRequestsMiddleware(
+                new Counter($storage, $limit, $window),
+                $responseFactory,
+                new LimitAlways(),
+                new TooManyRequestsMiddleware($responseFactory),
+            ),
             $responseFactory,
-            new LimitAlways(),
-            new TooManyRequestsMiddleware($responseFactory),
         );
     }
 
@@ -39,23 +48,26 @@ final class RateLimiter
      */
     public static function perIp(int $limit, string $salt, int $window = 60): Closure
     {
-        return static fn (ResponseFactoryInterface $responseFactory, StorageInterface $storage) => new LimitRequestsMiddleware(
-            new Counter($storage, $limit, $window),
+        return static fn (ResponseFactoryInterface $responseFactory, StorageInterface $storage) => new RateLimitRedirectMiddleware(
+            new LimitRequestsMiddleware(
+                new Counter($storage, $limit, $window),
+                $responseFactory,
+                new LimitCallback(static function (ServerRequestInterface $r) use ($salt): string {
+                    $srv = $r->getServerParams();
+                    $cfIp = isset($srv['HTTP_CF_CONNECTING_IP']) ? (string) $srv['HTTP_CF_CONNECTING_IP'] : '';
+                    $xfw = isset($srv['HTTP_X_FORWARDED_FOR']) ? (string) $srv['HTTP_X_FORWARDED_FOR'] : '';
+                    $rem = isset($srv['REMOTE_ADDR']) ? (string) $srv['REMOTE_ADDR'] : '';
+                    $ip = match (true) {
+                        $cfIp !== '' => $cfIp,
+                        $xfw !== '' => $xfw,
+                        $rem !== '' => $rem,
+                        default => 'unknown',
+                    };
+                    return hash('sha256', $salt . $ip);
+                }),
+                new TooManyRequestsMiddleware($responseFactory),
+            ),
             $responseFactory,
-            new LimitCallback(static function (ServerRequestInterface $r) use ($salt): string {
-                $srv = $r->getServerParams();
-                $cfIp = isset($srv['HTTP_CF_CONNECTING_IP']) ? (string) $srv['HTTP_CF_CONNECTING_IP'] : '';
-                $xfw = isset($srv['HTTP_X_FORWARDED_FOR']) ? (string) $srv['HTTP_X_FORWARDED_FOR'] : '';
-                $rem = isset($srv['REMOTE_ADDR']) ? (string) $srv['REMOTE_ADDR'] : '';
-                $ip = match (true) {
-                    $cfIp !== '' => $cfIp,
-                    $xfw !== '' => $xfw,
-                    $rem !== '' => $rem,
-                    default => 'unknown',
-                };
-                return hash('sha256', $salt . $ip);
-            }),
-            new TooManyRequestsMiddleware($responseFactory),
         );
     }
 }


### PR DESCRIPTION
"Too many requests" on login was rendering as raw, unstyled text (no `Content-Type`, no HTML) — confirmed directly in the vendor package: `LimitRequestsMiddleware::createErrorResponse()` just writes the bare status text into the body with nothing else, which every browser renders as default black-on-white serif text.

New `RateLimitRedirectMiddleware` wraps the rate limiter (used by `RateLimiter::global()`/`perIp()`, the shared builders every rate-limited auth route uses) and turns a 429 into a plain 302 back to the request URI — mirroring `AuthController::login()`'s own separate, controller-level rate-limit check, which already does exactly this.

**Found and fixed a real regression via live testing** (not caught by the first unit-test pass): `RateLimiter::perIp(5, 'login_route')` shares one counter across both GET and POST on `/login`. Once 429s became redirects, a GET page view that itself tripped the limit would redirect back to that same over-budget GET — an infinite loop, reproduced live as a real `ERR_TOO_MANY_REDIRECTS`. Fixed by skipping the inner limiter entirely for safe methods (GET/HEAD/OPTIONS), matching `AuthController::login()`'s own existing POST-only scoping.

Verified: `php -l` clean, full-project Psalm clean, Testo Unit 833/833 (5 new tests, including one reproducing the exact GET-loop regression), full PHPUnit Unit 3854/3854. Live-confirmed via Playwright against the real running app: 5 rapid POSTs return 200/200/200/200/302 (the 5th trips the configured limit exactly) instead of a raw 429, no redirect loop across 10 repeated attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests that exceed rate limits now redirect to the original page instead of displaying a bare rate-limit error.
  * GET, HEAD, and OPTIONS requests bypass rate-limit checks.
  * Other responses continue to be handled unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->