### PR TITLE
feat(inv): gate the UK tax point note on GBP/UK locale, not debug mode

### DIFF
--- a/src/Invoice/Inv/Trait/Edit.php
+++ b/src/Invoice/Inv/Trait/Edit.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Invoice\Inv\Trait;
 
-use App\Auth\Permissions;
 use App\Infrastructure\Persistence\Payment\Payment;
 use App\Invoice\{
     Inv\InvEditCoreDeps,
@@ -51,8 +50,15 @@ trait Edit
         $peppol_array = new PeppolArrays();
         $note_on_tax_point = '';
         $defaultGroupId = (int) $this->sR->getSetting('default_invoice_group');
-        if (($this->sR->getSetting('debug_mode') == '1')
-                && $this->userService->hasPermission(Permissions::EDIT_INV)) {
+        // Tax point is a UK VAT concept (references informi.co.uk, UK VAT
+        // reporting rules) — only relevant, so only shown, for the GBP/UK
+        // locale. Both must hold: the session locale is 'en', and that
+        // locale's own flag (SettingLocaleTrait::getLocaleFlags()) is
+        // 'gb' — belt-and-braces against the flag mapping drifting
+        // independently of the locale code later.
+        $locale = (string) $this->session->get('_language');
+        if ($locale === 'en'
+                && ($this->sR->getLocaleFlags()[$locale] ?? null) === 'gb') {
             $note_on_tax_point = $this->webViewRenderer->renderPartialAsString(
                 '//invoice/info/taxpoint');
         }


### PR DESCRIPTION
## Summary
The `inv/edit` form's "Tax Point" explainer note (`resources/views/invoice/info/taxpoint.php`) is a genuinely UK-specific VAT concept — it was previously gated behind `debug_mode == '1'` + edit permission, effectively hidden from real users rather than shown to the audience it's actually relevant to.

Now shown only when both hold:
- the session locale is `'en'`
- that locale's own flag (`SettingLocaleTrait::getLocaleFlags()`) is `'gb'`

## Verification
- `php -l` clean.
- Psalm (`--no-cache`, this file): no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tax-point information is now displayed only for the intended English (GB) locale.
  * Removed an unused permission reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->